### PR TITLE
harden: enforce install-time permissions and add systemd sandboxing

### DIFF
--- a/fan-control.service
+++ b/fan-control.service
@@ -10,6 +10,9 @@ WorkingDirectory=/data/fan-control
 ExecStart=/data/fan-control/fan-control.sh
 Restart=always
 RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
 # 24h window for log rate limiting
 LogRateLimitIntervalSec=86400
 # Allow 10k logs/day

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,9 @@ if [ ! -w "/data/fan-control" ]; then
     exit 1
 fi
 
+chown root:root /data/fan-control
+chmod 700 /data/fan-control
+
 # Function to get a file from local directory or download from GitHub
 get_file() {
     local filename="$1"
@@ -63,15 +66,24 @@ get_file() {
 
 # Get fan control script
 get_file "fan-control.sh" "/data/fan-control/fan-control.sh"
-chmod +x /data/fan-control/fan-control.sh
+chown root:root /data/fan-control/fan-control.sh
+chmod 755 /data/fan-control/fan-control.sh
 
 # Get uninstall script
 get_file "uninstall.sh" "/data/fan-control/uninstall.sh"
-chmod +x /data/fan-control/uninstall.sh
+chown root:root /data/fan-control/uninstall.sh
+chmod 755 /data/fan-control/uninstall.sh
+
+if [ -f /data/fan-control/config ]; then
+    chown root:root /data/fan-control/config
+    chmod 600 /data/fan-control/config
+fi
 
 # Install systemd service
 SERVICE_FILE="/etc/systemd/system/fan-control.service"
 get_file "fan-control.service" "$SERVICE_FILE"
+chown root:root "$SERVICE_FILE"
+chmod 644 "$SERVICE_FILE"
 
 # Verify service file was created
 if [ ! -f "$SERVICE_FILE" ]; then


### PR DESCRIPTION
## Description

Defense-in-depth hardening for the root service: enforce explicit ownership/permissions at install time instead of relying on the installer's umask, and add basic systemd sandboxing. No functional change to fan control.

_(No linked issue — hardening; related to `SECURITY.md`.)_

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Configuration change

## Changes Made

- **install.sh**: explicit `chown root:root` + restrictive modes — `700` on the data dir, `600` on config, `755` on scripts, `644` on the unit — instead of trusting the installer's umask. Because `fan-control.sh` `source`s the config as root, a group/world-writable config (e.g. under a loose umask) was a local privilege-escalation path; this closes it.
- **fan-control.service**: add `NoNewPrivileges`, `PrivateTmp`, `ProtectHome` to shrink the blast radius of the root service.

## Testing

### Test Environment

- **Device Model**: UDR7
- **UniFi OS Version**: _(please add)_

### Test Scenarios

- [x] Service restart
- [x] Other: service starts and controls fans with the sandbox directives applied; `bash -n` clean

## Configuration Impact

- [x] No configuration changes required

## Breaking Changes

- None expected. The permission tightening applies to files the service already owns; the sandbox directives are compatible with sysfs PWM writes (validated on UDR7).

## Safety Considerations

- [x] No change to fan-control logic; PWM behavior unchanged

## Additional Notes

- Deliberately a conservative sandbox set. Stronger confinement (`ProtectSystem=strict` + `ReadWritePaths` for the hwmon/`/data`/`/run` paths) is possible but needs per-device testing, because sysfs PWM writes can conflict with `ProtectSystem`/`ProtectKernelTunables`. Left out here to avoid breaking cooling on models I can't test.

---

**By submitting this PR, I confirm that**:
- [x] I have read and agree to follow the Code of Conduct
- [x] I have read the Contributing Guidelines
- [x] My contribution is licensed under the MIT License
