### PR TITLE
fix: compute real |saved-raw| absolute difference in saved-temp boots…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#17](https://github.com/iceteaSA/unifi-fan-control/issues/17): Lock and cleanup trap were registered in a subshell that exited immediately. Moved `flock` and `trap` to the parent shell so the lock is held for the daemon's lifetime, cleanup runs on actual exit, and single-instance guard is authoritative.
 - [#18](https://github.com/iceteaSA/unifi-fan-control/issues/18): `get_smoothed_temp` was called via `$(...)`, losing `TEMP_READ_FAILURES` and `SMOOTHED_TEMP` mutations in subshells. Rewrote to communicate via globals; added a sensor fail-safe in `update_fan_state` that forces `MAX_PWM` after 3 consecutive read failures, bypassing state-machine and ramp limits.
+- Saved-temp bootstrap used `(( ${saved_temp#-} - ${raw_temp#-} < 15 ))` to guard against re-initialising to a stale persisted smoothed temp. The `${var#-}` form strips a leading minus from *each operand independently* and does **not** compute `|saved - raw|`, so only the `saved > raw` direction was guarded. On a hot restart with a stale low saved temp (`raw > saved`), the difference was negative, always `< 15`, and `SMOOTHED_TEMP` was re-initialised to the stale low value — leaving the coldstart fan-OFF decision at line 774 to run against a too-low temp and keeping the fan OFF for one full `CHECK_INTERVAL`. Replaced with a real absolute difference; added `tests/test_regression_saved_temp_bootstrap.sh`.
 
 ## Recent Changes (Based on Git History)
 

--- a/fan-control.sh
+++ b/fan-control.sh
@@ -444,7 +444,15 @@ if [[ -f "$TEMP_STATE_FILE" ]]; then
     # Validate saved temperature is a number and within reasonable range
     if [[ "$saved_temp" =~ ^[0-9]+$ ]] && (( saved_temp >= 20 && saved_temp <= 100 )); then
         # Don't use saved temp if it's too far from current raw temp (prevents large jumps)
-        if (( ${saved_temp#-} - ${raw_temp#-} < 15 )); then
+        # Compute the real absolute difference |saved - raw| — the previous
+        # `${saved_temp#-} - ${raw_temp#-}` form only stripped a leading minus
+        # from each operand independently and did NOT take |saved - raw|, so a
+        # hot restart with a stale low saved temp (raw > saved) always passed
+        # the < 15 guard and re-initialised SMOOTHED_TEMP to the stale value,
+        # potentially keeping the fan OFF on a hot boot until the next loop tick.
+        init_delta=$(( saved_temp - raw_temp ))
+        (( init_delta < 0 )) && init_delta=$(( -init_delta ))
+        if (( init_delta < 15 )); then
             SMOOTHED_TEMP=$saved_temp
             logger -t fan-control "INIT: Loaded saved temp=${SMOOTHED_TEMP}°C | Raw=${raw_temp}°C"
         else

--- a/tests/test_regression_saved_temp_bootstrap.sh
+++ b/tests/test_regression_saved_temp_bootstrap.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+###############################################################################
+# Regression test: saved-temp bootstrap must compute the real |saved - raw|
+# absolute difference before deciding whether to reuse the persisted smoothed
+# temperature.
+#
+# Bug: fan-control.sh used `(( ${saved_temp#-} - ${raw_temp#-} < 15 ))` to
+# guard against re-initialising to a stale saved temp. The `${var#-}` form
+# only strips a leading minus from *each operand independently* — it does
+# NOT compute |saved - raw|. So only the `saved > raw` direction was guarded;
+# when `raw > saved` (hot boot with a stale low saved temp) the difference
+# was negative, always < 15, and SMOOTHED_TEMP was re-initialised to the
+# stale low value. The subsequent coldstart decision at line 774
+# (`SMOOTHED_TEMP >= FAN_ACTIVATION_TEMP`) ran BEFORE the smoothing loop, so
+# a hot restart could keep the fan OFF for one full CHECK_INTERVAL.
+#
+# This test reproduces the symptom: a hot boot (raw=70°C) with a stale low
+# persisted temp (saved=40°C). The bogus guard accepts the 40°C initiation;
+# the coldstart branch then logs "Fans off" instead of going ACTIVE. The
+# fix computes the real absolute difference (|70-40|=30 > 15 → discard) and
+# boots into ACTIVE.
+#
+# Red check: this test MUST fail against the unfixed line 447, because the
+# daemon inits SMOOTHED_TEMP=40 and the coldstart branch sees
+# 40 < FAN_ACTIVATION_TEMP (60+5=65) → "Fans off".
+###############################################################################
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/harness.sh"
+trap teardown_sandbox EXIT
+
+setup_sandbox
+
+# Force a hot boot: raw temp held high throughout
+echo "70" > "$SANDBOX/cputemp"
+
+# Pre-seed the persisted temp_state with a stale LOW value that the buggy
+# guard would wrongly accept (raw > saved by 30°C).
+echo "40" > "$FAN_CONTROL_TEMP_STATE_FILE"
+
+# Boot the daemon
+start_daemon
+assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive"
+
+# Give it time to bootstrap and log the coldstart decision
+/bin/sleep 1
+
+# With the fix: |40-70|=30 ≥ 15 → saved discarded, SMOOTHED_TEMP init to 70,
+# and FAN_ACTIVATION_TEMP (60+5=65) ≤ 70 → coldstart goes ACTIVE.
+# Without the fix: 40 - 70 = -30 < 15 → saved accepted, SMOOTHED_TEMP=40,
+# 40 < 65 → coldstart logs "Fans off".
+if ! grep -q "COLDSTART: Initial temp 70°C ≥ 65°C" "$SANDBOX/syslog"; then
+    echo "--- syslog ---" >&2
+    cat "$SANDBOX/syslog" >&2
+    fail "Hot boot did not go ACTIVE with discarded stale saved temp"
+fi
+
+if grep -q "COLDSTART: Initial temp 40°C" "$SANDBOX/syslog"; then
+    echo "--- syslog ---" >&2
+    cat "$SANDBOX/syslog" >&2
+    fail "Stale low saved temp (40°C) was wrongly accepted on hot boot (raw=70°C)"
+fi
+
+echo "  ✓ Hot boot (raw=70°C) discarded stale saved temp (40°C) and went ACTIVE"
+echo "  ✓ INIT:COLDSTART correctly used real |saved - raw| absolute difference"
+
+stop_daemon
+cleanup_sandbox
+
+echo "  All saved-temp bootstrap regression tests passed."


### PR DESCRIPTION
## Summary

The saved-temp bootstrap guard at `fan-control.sh:447` used `((${saved_temp#-} - ${raw_temp#-} < 15 ))` to avoid re-initialising `SMOOTHED_TEMP` to a stale persisted value. The `${var#-}` form strips a leading minus from **each operand independently** — it does **not** compute `|saved - raw|`. Only the `saved > raw` direction was guarded; when `raw > saved` (hot restart with a stale low saved temp) the difference was negative, always `< 15`, and `SMOOTHED_TEMP` was re-initialised to the stale low value. The coldstart fan-OFF decision at line 774 (`SMOOTHED_TEMP >= FAN_ACTIVATION_TEMP`) then ran against a too-low temp, keeping the fan OFF for one full `CHECK_INTERVAL` on a hot boot.

This replaces the bogus expression with a real absolute difference and adds a regression test.

## Changes

- `fan-control.sh`: compute real `|saved - raw|` before the `< 15` guard.
- `tests/test_regression_saved_temp_bootstrap.sh`: new regression test — hot boot raw=70°C + stale saved=40°C → must coldstart ACTIVE, not "Fans off". Red on unfixed line 447, green with fix.
- `CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Test plan

- [x] `bash -n fan-control.sh tests/test_regression_saved_temp_bootstrap.sh` passes
- [x] New test red against unmodified code (mutant check via `git stash`)
- [x] New test green with fix applied
- [x] `bash tests/run-tests.sh` — 7 passed, 1 failed (pre-existing macOS-only `grep -oP` PCRE failure in `test_regression_18_smoothing.sh`, unrelated)

## Notes

No new parameters, no config-rewrite blocks touched, EXIT trap / PWM reset paths unchanged. The fix is one arithmetic guard + a comment; the rest is test + changelog.

## AI Assistance Disclosure

This gap and the fix were identified and implemented by AI (GLM 5.2), however I have verified the outcome on on my devices to ensure they are valid.