### PR TITLE
ci: add bash/mawk test matrix and shellcheck baseline

### DIFF
--- a/.github/shellcheck-baseline.tsv
+++ b/.github/shellcheck-baseline.tsv
@@ -1,0 +1,43 @@
+fan-control.sh	SC1090	warning	ShellCheck can't follow non-constant source. Use a directive to specify location.
+fan-control.sh	SC2046	warning	Quote this to prevent word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2086	info	Double quote to prevent globbing and word splitting.
+fan-control.sh	SC2155	warning	Declare and assign separately to avoid masking return values.
+fan-control.sh	SC2155	warning	Declare and assign separately to avoid masking return values.
+fan-control.sh	SC2155	warning	Declare and assign separately to avoid masking return values.
+fan-control.sh	SC2155	warning	Declare and assign separately to avoid masking return values.
+fan-control.sh	SC2155	warning	Declare and assign separately to avoid masking return values.
+fan-control.sh	SC2155	warning	Declare and assign separately to avoid masking return values.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+fan-control.sh	SC2254	warning	Quote expansions in case patterns to match literally rather than as a glob.
+install.sh	SC2181	style	Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.
+tests/lib/harness.sh	SC2034	warning	TEST_DIR appears unused. Verify use (or export if used externally).
+tests/test_config_bootstrap.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).
+tests/test_pwm_detection.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).
+tests/test_regression_17_lifecycle.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).
+tests/test_regression_18_failsafe.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).
+tests/test_regression_18_smoothing.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).
+tests/test_regression_26_curve.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).
+tests/test_regression_26_curve.sh	SC2034	warning	FAN_ACTIVATION_TEMP appears unused. Verify use (or export if used externally).
+tests/test_regression_26_curve.sh	SC2034	warning	MAX_PWM appears unused. Verify use (or export if used externally).
+tests/test_regression_26_curve.sh	SC2034	warning	MAX_TEMP appears unused. Verify use (or export if used externally).
+tests/test_regression_saved_temp_bootstrap.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).
+tests/test_state_machine.sh	SC1091	info	Not following: ./lib/harness.sh was not specified as input (see shellcheck -x).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Install lint tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck shfmt jq
+      - name: Bash syntax
+        shell: bash
+        run: |
+          mapfile -t shell_files < <(git ls-files '*.sh')
+          bash -n "${shell_files[@]}"
+      - name: ShellCheck baseline
+        shell: bash
+        run: |
+          mapfile -t shell_files < <(git ls-files '*.sh')
+          set +e
+          shellcheck -f json1 "${shell_files[@]}" > /tmp/shellcheck.json
+          shellcheck_status=$?
+          set -e
+          if (( shellcheck_status > 1 )); then
+              exit "$shellcheck_status"
+          fi
+          jq -r '.comments[] | [.file, ("SC" + (.code | tostring)), .level, .message] | @tsv' /tmp/shellcheck.json \
+            | LC_ALL=C sort > /tmp/shellcheck-current.tsv
+          diff -u .github/shellcheck-baseline.tsv /tmp/shellcheck-current.tsv
+      # Task 7 activates the hard shfmt gate after the Phase 2 reformat.
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: bash-4.4-mawk
+            image: bash:4.4
+          - target: bash-5.1-mawk
+            image: bash:5.1
+          - target: bash-5.2-mawk
+            image: bash:5.2
+          - target: ubuntu-native-mawk
+            image: native
+    name: test (${{ matrix.target }})
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Test in official Bash image
+        if: matrix.image != 'native'
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            "${{ matrix.image }}" \
+            sh -ec 'apk add --no-cache mawk; mawk -W version; bash --version | head -n 1; bash tests/run-tests.sh'
+      - name: Test on native runner with mawk
+        if: matrix.image == 'native'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mawk
+          sudo update-alternatives --set awk /usr/bin/mawk
+          mawk -W version
+          bash --version | head -n 1
+          bash tests/run-tests.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Adaptive fan controller for UniFi OS devices (UCG-Max, UCG-Fibre, UXG-Fibre, UDM-SE, UDM-Pro-Max, UDR7, UNVR). Pure bash — no build system, no package manager, no CI.
+Adaptive fan controller for UniFi OS devices (UCG-Max, UCG-Fibre, UXG-Fibre, UDM-SE, UDM-Pro-Max, UDR7, UNVR). Pure bash — no build system or package manager.
 
 ## What this repo actually is
 
@@ -11,9 +11,16 @@ Adaptive fan controller for UniFi OS devices (UCG-Max, UCG-Fibre, UXG-Fibre, UDM
 
 ## Verification
 
-- `bash -n fan-control.sh install.sh uninstall.sh` — the only local gate. Passes clean today.
-- `tests/run-tests.sh` — sandboxed test suite (no device, no root needed). All 7 tests pass. Uses `FAN_CONTROL_*` env seams to override device paths for testing.
-- `shellcheck fan-control.sh` has ~36 pre-existing findings; do not treat a nonzero exit as a regression, only avoid adding new ones.
+The four local gates matching CI are:
+
+```bash
+bash -n fan-control.sh install.sh uninstall.sh tests/*.sh tests/lib/*.sh
+bash tests/run-tests.sh
+shellcheck fan-control.sh install.sh uninstall.sh tests/*.sh tests/lib/*.sh
+shfmt -i 4 -ci -d fan-control.sh install.sh uninstall.sh tests/*.sh tests/lib/*.sh
+```
+
+The sandboxed suite has 9 tests after Phase 0 and needs no device or root; it uses `FAN_CONTROL_*` env seams to override device paths. CI tests Bash 4.4, 5.1, 5.2, and native Ubuntu under mawk. The ShellCheck baseline in `.github/shellcheck-baseline.tsv` is temporary debt until Phase 2, not permission to add new warnings.
 - Nothing here runs on a dev machine: the script hard-requires `ubnt-systool` (UniFi-only) and writable `/sys/class/hwmon/*/pwm*`. Real testing means deploying to a device and watching `journalctl -u fan-control.service -f`. CONTRIBUTING.md lists the manual test scenarios (cold start, hot start, state transitions, sensor failure).
 - To test a branch on a device: `sudo FAN_CONTROL_BRANCH=<branch> ./install.sh` (or the curl one-liner against that branch).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
    - Add comments for complex logic
    - Update documentation if needed
 3. **Test your changes**:
+   - Run all four local verification gates listed below
+   - Keep pull requests green across the CI Bash/mawk matrix
    - Test on actual hardware if possible
    - Verify all operational states work correctly
    - Check logs for errors or warnings
@@ -79,6 +81,17 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 
 ### Testing
 
+Run the same four local gates used by CI:
+
+```bash
+bash -n fan-control.sh install.sh uninstall.sh tests/*.sh tests/lib/*.sh
+bash tests/run-tests.sh
+shellcheck fan-control.sh install.sh uninstall.sh tests/*.sh tests/lib/*.sh
+shfmt -i 4 -ci -d fan-control.sh install.sh uninstall.sh tests/*.sh tests/lib/*.sh
+```
+
+The sandboxed suite has 9 tests after Phase 0. CI tests Bash 4.4, 5.1, 5.2, and native Ubuntu under mawk. The ShellCheck baseline in `.github/shellcheck-baseline.tsv` is temporary debt until Phase 2; it does not permit adding new warnings.
+
 When making changes, test the following scenarios:
 
 1. **Cold start**: Script starts with system below MIN_TEMP
@@ -109,6 +122,7 @@ unifi-fan-control/
 ├── TROUBLESHOOTING.md      # Common issues and solutions
 ├── SECURITY.md             # Security policy
 ├── CODE_OF_CONDUCT.md      # Community guidelines
+├── .github/workflows/ci.yml # CI matrix and lint gates
 └── LICENSE                 # MIT License
 ```
 

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -46,11 +46,13 @@ setup_sandbox() {
 
     # Create stub bin directory PREPENDED to PATH
     mkdir -p "$SANDBOX/bin"
+    local real_sleep_path
+    real_sleep_path=$(command -v sleep)
     export PATH="$SANDBOX/bin:$PATH"
 
     # Stub: ubnt-systool — reads $SANDBOX/cputemp; exits 1 on missing or FAIL
     cat > "$SANDBOX/bin/ubnt-systool" <<'STUB'
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$1" != "cputemp" ]]; then
     echo "unknown arg: $*" >&2
     exit 1
@@ -69,15 +71,15 @@ STUB
 
     # Stub: logger — appends arguments to $SANDBOX/syslog
     cat > "$SANDBOX/bin/logger" <<'STUB'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "$@" >> "${SANDBOX:-/tmp}/syslog"
 STUB
     chmod +x "$SANDBOX/bin/logger"
 
     # Stub: sleep — accelerates daemon loop by sleeping 0.05s
-    cat > "$SANDBOX/bin/sleep" <<'STUB'
-#!/bin/bash
-exec /bin/sleep 0.05
+    cat > "$SANDBOX/bin/sleep" <<STUB
+#!/usr/bin/env bash
+exec "$real_sleep_path" 0.05
 STUB
     chmod +x "$SANDBOX/bin/sleep"
 

--- a/tests/test_pwm_detection.sh
+++ b/tests/test_pwm_detection.sh
@@ -47,7 +47,15 @@ cleanup_sandbox
 scenario=$((scenario + 1))
 setup_sandbox
 
-chmod 444 "$SANDBOX/hwmon/hwmon0/pwm1"
+# Root can write mode-444 regular files, which is the default user in the
+# official Docker Bash images. A directory keeps the candidate present while
+# making the daemon's write-back probe fail for every user.
+if (( EUID == 0 )); then
+    rm "$SANDBOX/hwmon/hwmon0/pwm1"
+    mkdir "$SANDBOX/hwmon/hwmon0/pwm1"
+else
+    chmod 444 "$SANDBOX/hwmon/hwmon0/pwm1"
+fi
 echo "50" > "$SANDBOX/cputemp"
 
 start_daemon

--- a/tests/test_pwm_detection.sh
+++ b/tests/test_pwm_detection.sh
@@ -47,9 +47,14 @@ cleanup_sandbox
 scenario=$((scenario + 1))
 setup_sandbox
 
-# Root can write mode-444 regular files, which is the default user in the
-# official Docker Bash images. A directory keeps the candidate present while
-# making the daemon's write-back probe fail for every user.
+# Root can write mode-444 regular files, and root is the default user in the
+# official Docker Bash images, so chmod alone cannot make a candidate unusable
+# there. A directory still satisfies the [[ -e ]] candidate scan but fails the
+# daemon's `cat` read, so the channel is rejected for every user.
+#
+# The two branches reach the same FATAL outcome by different guards: non-root
+# fails the write-back probe ("not writable, skipping"), root fails the read
+# that precedes it. Only the non-root path covers the write-back probe itself.
 if (( EUID == 0 )); then
     rm "$SANDBOX/hwmon/hwmon0/pwm1"
     mkdir "$SANDBOX/hwmon/hwmon0/pwm1"

--- a/tests/test_regression_18_smoothing.sh
+++ b/tests/test_regression_18_smoothing.sh
@@ -41,7 +41,7 @@ echo "70" > "$SANDBOX/cputemp"
 
 # Collect SMOOTH values from TEMP: log lines — all of these are POST-jump.
 # Format: "TEMP:  RAW=70°C | SMOOTH=66°C | DELTA=-4°C"
-smoothed_values=$(grep -oP 'SMOOTH=\K\d+' "$SANDBOX/syslog" 2>/dev/null || true)
+smoothed_values=$(sed -n 's/.*SMOOTH=\([0-9][0-9]*\).*/\1/p' "$SANDBOX/syslog" 2>/dev/null || true)
 
 if [[ -z "$smoothed_values" ]]; then
     echo "--- syslog ---" >&2


### PR DESCRIPTION
First CI for this repo. Until now every contributor PR was verified by hand.

## What runs

**`lint`** — `bash -n` over `git ls-files '*.sh'`, then shellcheck diffed against a committed baseline.

**`test`** — the suite on four targets:

| Target | Why |
|---|---|
| `bash:5.1` | Device parity — a UCG-Max reports `5.1.4(1)-release` |
| `bash:5.2` | Current stable |
| `bash:4.4` | Compatibility floor for older UniFi OS |
| `ubuntu-latest` | Native runner sanity |

Every leg installs **mawk**, because the device runs mawk 1.3.4 and `fan-control.sh` deliberately uses `awk` for float smoothing — integer bash arithmetic caused drift previously. A gawk-only CI would test an implementation that never ships.

## Shellcheck baseline

`.github/shellcheck-baseline.tsv`, 43 rows, generated by the same `shellcheck -f json1 | jq | sort` pipeline CI runs. CI diffs against it, so **new** findings fail while existing debt does not block.

It is generated, never hand-edited. Regenerate with the pipeline in the workflow.

This is temporary debt, not permission to add warnings — a follow-up PR takes it to zero and flips the gate to hard-zero.

## Not in this PR

The shfmt gate. Formatting the tree is a ~967-line diff and belongs in its own commit with its own review; landing a hard shfmt gate here would put `main` red the moment this merges. Line 43 marks where it activates.

No `continue-on-error`, no `|| true`. A gate that cannot fail is worse than no gate.

## Notes

- `actions/checkout` pinned to `08eba0b27e820071cde6df949e0beb9ba4906955` (v4.3.0); verified the SHA resolves to that tag.
- Bash images run via `docker run` rather than as `container:` jobs — JavaScript actions are unreliable in musl-only containers.
- `permissions: contents: read`, concurrency cancels superseded runs.
- AGENTS.md and CONTRIBUTING.md updated: the "no CI", "only local gate", "7 tests", and "~36 findings" claims were all stale.

Verified locally: `bash -n` clean, `9 passed, 0 failed, 9 total`, baseline regenerates byte-identical. The matrix itself can only be verified by this PR's own run.