### PR TITLE
ci: allow building release assets for an existing tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,19 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build and upload assets for (e.g. v0.9.0-rc1). The GitHub release for this tag must already exist."
+        required: true
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -17,19 +23,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: release
+        if: github.event_name == 'push'
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        if: steps.release.outputs.release_created == 'true'
-        with:
-          ref: ${{ steps.release.outputs.sha }}
-      - name: Build and verify release assets
-        if: steps.release.outputs.release_created == 'true'
+      - id: target
         shell: bash
         env:
-          VERSION: ${{ steps.release.outputs.version }}
+          EVENT: ${{ github.event_name }}
+          RP_CREATED: ${{ steps.release.outputs.release_created }}
+          RP_TAG: ${{ steps.release.outputs.tag_name }}
+          RP_VERSION: ${{ steps.release.outputs.version }}
+          RP_SHA: ${{ steps.release.outputs.sha }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          build=false; tag=""; version=""; ref=""
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+              tag="$INPUT_TAG"
+              version="${tag#v}"
+              ref="$tag"
+              build=true
+          elif [[ "$RP_CREATED" == "true" ]]; then
+              tag="$RP_TAG"; version="$RP_VERSION"; ref="$RP_SHA"; build=true
+          fi
+          { echo "build=$build"; echo "tag=$tag"; echo "version=$version"; echo "ref=$ref"; } >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        if: steps.target.outputs.build == 'true'
+        with:
+          ref: ${{ steps.target.outputs.ref }}
+      - name: Build and verify release assets
+        if: steps.target.outputs.build == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.target.outputs.version }}
         run: |
           set -euo pipefail
           test "$(cat VERSION)" = "$VERSION"
@@ -45,11 +73,11 @@ jobs:
           sha256sum "$archive" > SHA256SUMS
           sha256sum -c SHA256SUMS
       - name: Upload release assets
-        if: steps.release.outputs.release_created == 'true'
+        if: steps.target.outputs.build == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ steps.release.outputs.tag_name }}
-          VERSION: ${{ steps.release.outputs.version }}
+          TAG_NAME: ${{ steps.target.outputs.tag }}
+          VERSION: ${{ steps.target.outputs.version }}
         run: |
           gh release upload "$TAG_NAME" \
             "unifi-fan-control-v${VERSION}.tar.gz" \


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to the release workflow so assets can be built and uploaded for a tag that already has a GitHub release.

## Why

The installer rework needs to be tested against a real release asset — real URL, real tarball, real `SHA256SUMS`. Cutting `v1.0.0` first to get one would mean publishing the "latest" release against a tarball contract **nothing has ever consumed**: no code has extracted and installed it yet. If the installer then needs a different layout, v1.0.0 is immediately superseded.

Instead: cut a `v0.9.0-rc1` prerelease, validate the installer against it, then cut v1.0.0. A prerelease never becomes "latest", so a malformed asset reaches nobody.

## The constraint that shaped this

The rc's assets have to be built by the **same code** that will build v1.0.0's. A second workflow or a second job with copy-pasted packaging would let the real path drift untested — which defeats the entire purpose.

So this is one job, one packaging block, two triggers. A `target` step normalizes both into `build` / `tag` / `version` / `ref`, and the existing steps key off that:

```yaml
if [[ "$EVENT" == "workflow_dispatch" ]]; then
    tag="$INPUT_TAG"; version="${tag#v}"; ref="$tag"; build=true
elif [[ "$RP_CREATED" == "true" ]]; then
    tag="$RP_TAG"; version="$RP_VERSION"; ref="$RP_SHA"; build=true
fi
```

Verified structurally: 1 job, 1 `tar` block, 1 `sha256sum -c`, 1 `gh release upload`.

## Assertion kept, deliberately

`test "$(cat VERSION)" = "$VERSION"` still runs on **both** paths, unconditionally. It catches a tag whose tree disagrees with its name, so weakening it for the dispatch path would remove the check exactly where a hand-cut tag makes it most likely to fire. The rc1 tag will be cut from a commit whose `VERSION` genuinely reads `0.9.0-rc1`.

## Concurrency

Changed to `release-${{ github.event_name }}-${{ github.ref }}`. With `cancel-in-progress: false`, a *pending* run in a group is displaced when a newer one arrives — so without this split, a dispatch could evict a queued automatic release.

## Unchanged

Four-entry tarball (`fan-control.sh`, `uninstall.sh`, `fan-control.service`, `VERSION` — no `install.sh`), reproducible tar flags, both pinned action SHAs, `permissions`.

## Verification

`bash -n` clean · shellcheck 0 · shfmt clean · `11 passed, 0 failed, 11 total`.

Resolution logic dry-run for all three cases (dispatch / push-with-release / push-without-release) produces the expected outputs; `v0.9.0-rc1` → version `0.9.0-rc1`.

The dispatch path itself can only be proven by running it — that happens next, when it cuts the rc1 assets.