### PR TITLE
chore: drop the release-as bootstrap pin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
     ".": {
       "package-name": "unifi-fan-control",
       "changelog-path": "CHANGELOG.md",
-      "version-file": "VERSION",
-      "release-as": "1.0.0"
+      "version-file": "VERSION"
     }
   }
 }


### PR DESCRIPTION
`release-as: "1.0.0"` existed to force the first release to 1.0.0 instead of 0.1.0. v1.0.0 is cut, so it has to go — left in place, every future release PR would propose 1.0.0 again.

Versions now come from conventional-commit types: `fix:` → patch, `feat:` → minor, `!`/`BREAKING CHANGE` → major.

Nothing else changes. `version-file`, `include-v-in-tag`, and the changelog path are untouched.