### PR TITLE
harden: enforce install permissions and add systemd sandboxing

### DIFF
--- a/fan-control.service
+++ b/fan-control.service
@@ -8,6 +8,9 @@ Type=simple
 User=root
 WorkingDirectory=/data/fan-control
 ExecStart=/data/fan-control/fan-control.sh
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
 Restart=always
 RestartSec=5
 # 24h window for log rate limiting

--- a/fan-control.sh
+++ b/fan-control.sh
@@ -3,6 +3,8 @@
 # UniFi Intelligent Fan Controller
 ###############################################################################
 
+umask 077
+
 ###[ CONFIGURATION ]###########################################################
 CONFIG_FILE="${FAN_CONTROL_CONFIG_FILE:-/data/fan-control/config}"
 TEMP_STATE_FILE="${FAN_CONTROL_TEMP_STATE_FILE:-/data/fan-control/temp_state}"

--- a/install.sh
+++ b/install.sh
@@ -349,6 +349,25 @@ replace_destination_files() {
     done
 }
 
+enforce_install_permissions() {
+    if [[ "${FAN_CONTROL_ALLOW_CHOWN_FAILURE:-0}" == 1 ]]; then
+        chown root:root "$INSTALL_DIR" 2>/dev/null || true
+    elif ! chown root:root "$INSTALL_DIR"; then
+        return 1
+    fi
+    if ! chmod 0700 "$INSTALL_DIR"; then
+        return 1
+    fi
+    if [[ -f "$INSTALL_DIR/config" ]]; then
+        if [[ "${FAN_CONTROL_ALLOW_CHOWN_FAILURE:-0}" == 1 ]]; then
+            chown root:root "$INSTALL_DIR/config" 2>/dev/null || true
+        elif ! chown root:root "$INSTALL_DIR/config"; then
+            return 1
+        fi
+        chmod 0600 "$INSTALL_DIR/config" || return 1
+    fi
+}
+
 rollback_install() {
     restore_previous_payload
     "$SYSTEMCTL" daemon-reload >/dev/null 2>&1 || true
@@ -371,6 +390,11 @@ install_validated_payload() {
     if ! replace_destination_files; then
         cleanup_destination_temps
         fail "Failed to replace installation files"
+    fi
+
+    if ! enforce_install_permissions; then
+        rollback_install
+        fail "Failed to enforce installation permissions"
     fi
 
     if ! "$SYSTEMCTL" daemon-reload; then

--- a/tests/test_config_bootstrap.sh
+++ b/tests/test_config_bootstrap.sh
@@ -20,6 +20,16 @@ rm -f "$SANDBOX/config"
 
 start_daemon
 assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive" "daemon should be running"
+assert_eq "$(stat -c%a "$SANDBOX/config")" "600" "new config mode: "
+echo "70" >"$SANDBOX/cputemp"
+for _ in {1..20}; do
+    [[ -f "$SANDBOX/temp_state" ]] && break
+    /bin/sleep 0.1
+done
+for state_file in "$SANDBOX/temp_state" "$SANDBOX/optimal_pwm" "$SANDBOX/pid"; do
+    [[ -f "$state_file" ]] || fail "daemon did not create $state_file"
+    assert_eq "$(stat -c%a "$state_file")" "600" "$(basename "$state_file") mode: "
+done
 
 declare -a required_params=(
     "MIN_PWM" "MAX_PWM" "MIN_TEMP" "MAX_TEMP" "HYSTERESIS"
@@ -66,6 +76,7 @@ assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive"
 
 min_temp=$(grep "^MIN_TEMP=" "$SANDBOX/config" | cut -d= -f2 | awk '{print $1}')
 assert_eq "$min_temp" "60" "MIN_TEMP should be clamped to default (60), got "
+assert_eq "$(stat -c%a "$SANDBOX/config")" "600" "corrected config mode: "
 
 echo "  ✓ Scenario ${scenario}: Corrupt numeric value clamped to default"
 
@@ -93,6 +104,7 @@ OPTIMAL_PWM_FILE="$SANDBOX/optimal_pwm"
 MAX_PWM_STEP=25
 ALPHA=20
 EOF
+chmod 600 "$SANDBOX/config"
 
 start_daemon
 assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive"
@@ -103,6 +115,7 @@ fi
 if ! grep -q "^LEARNING_RATE=" "$SANDBOX/config"; then
     fail "LEARNING_RATE should have been re-appended"
 fi
+assert_eq "$(stat -c%a "$SANDBOX/config")" "600" "re-appended config mode: "
 
 echo "  ✓ Scenario ${scenario}: Missing parameters re-appended"
 

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -230,6 +230,7 @@ install_environment() {
     env \
         FAN_CONTROL_INSTALL_DIR="$INSTALL_DIR" \
         FAN_CONTROL_SERVICE_FILE="$SERVICE_FILE" \
+        FAN_CONTROL_ALLOW_CHOWN_FAILURE=1 \
         FAN_CONTROL_SYSTEMCTL=systemctl \
         FAN_CONTROL_RELEASE_BASE_URL="https://releases.example.invalid/project/releases" \
         CURL_LOG="$CURL_LOG" \
@@ -254,6 +255,7 @@ install_piped_environment() {
         cat install.sh | env \
             FAN_CONTROL_INSTALL_DIR="$INSTALL_DIR" \
             FAN_CONTROL_SERVICE_FILE="$SERVICE_FILE" \
+            FAN_CONTROL_ALLOW_CHOWN_FAILURE=1 \
             FAN_CONTROL_SYSTEMCTL=systemctl \
             FAN_CONTROL_RELEASE_BASE_URL="https://releases.example.invalid/project/releases" \
             CURL_LOG="$CURL_LOG" \
@@ -499,8 +501,10 @@ test_verified_release_installs_and_preserves_config() {
     install_environment FAN_CONTROL_VERSION=1.2.3
 
     assert_file_set
+    assert_eq "$(stat -c%a "$INSTALL_DIR")" "700" "install directory mode: "
     assert_eq "$(cat "$INSTALL_DIR/VERSION")" "$MOCK_VERSION" "installed release version: "
     assert_eq "$(cat "$INSTALL_DIR/config")" "MIN_TEMP=48" "config preservation: "
+    assert_eq "$(stat -c%a "$INSTALL_DIR/config")" "600" "installed config mode: "
     assert_eq "$(cat "$SYSTEMCTL_LOG")" $'is-active --quiet fan-control.service\ndaemon-reload\nenable --now fan-control.service\nis-active --quiet fan-control.service' "systemctl order: "
 }
 


### PR DESCRIPTION
Rework of #20 by @bgpntx against current `main`. His branch no longer applies — `install.sh` was rewritten underneath it — so this reimplements the same idea and keeps him as co-author.

## What was still missing

Half of #20 landed incidentally during the installer rework. Checked each piece against `main` and against a live UCG-Max:

| From #20 | Status |
|---|---|
| `chmod 0755` on scripts | already landed |
| `chmod 0644` on the unit | already landed |
| `chmod 700` + `chown` on `/data/fan-control` | missing — device showed `755` |
| `chmod 600` + `chown` on config | missing — device showed `644` |
| `NoNewPrivileges` / `PrivateTmp` / `ProtectHome` | missing |

His reasoning holds: the daemon `source`s the config as root, so a group- or world-writable config is a local privilege-escalation path.

## The part his patch alone wouldn't have fixed

An install-time `chmod 600` doesn't survive. The daemon rewrites its own config with a tmp-file + `mv` under the default `umask 022`, so the first `validate_config` clamp or `check_param` append hands the permissions straight back:

```
before:                          600
after tmp+mv under umask 022:    644   ← install-time chmod undone
after tmp+mv under umask 077:    600   ← survives
```

So `install.sh` alone would have looked hardened and quietly decayed on the next config touch. `fan-control.sh` now sets `umask 077` at the top, which covers every write site including ones added later.

Resulting modes for everything the daemon creates: `config` 600, `temp_state` 600, `optimal_pwm` 600, `/var/run/fan-control.pid` 600. Nothing else consumes these files and the service runs as root, so nothing lost read access. sysfs PWM files already exist, so umask doesn't touch them.

## systemd sandboxing

```
NoNewPrivileges=true
PrivateTmp=true
ProtectHome=true
```

Verified safe on the target rather than assumed: the device runs systemd 247, the daemon uses no `/tmp`, and its PID file lives in `/var/run` where `PrivateTmp` doesn't reach.

`ProtectSystem=strict` and `ProtectKernelTunables` stay out. They can block `/sys/class/hwmon/*/pwm*` writes, which would break cooling on hardware nobody here can test. bgpntx left them out deliberately and called out why — that judgment carried over unchanged.

## Tests

Two new assertions, both mutation-checked:

| Mutation | Result |
|---|---|
| Remove `umask 077` | `FAIL: new config mode: expected '600', got '644'` |
| Neuter `enforce_install_permissions` | `FAIL: install directory mode: expected '700', got '755'` |

The one that matters seeds a `600` config, triggers a rewrite by omitting parameters the daemon re-appends, and asserts the mode is still `600` afterwards. That's the decay a permissions-only patch wouldn't have caught.

## One note on the sandboxed tests

`chown root:root` can't run unprivileged, so tests set `FAN_CONTROL_ALLOW_CHOWN_FAILURE=1`, which tolerates a failing `chown` only. The `chmod 0700`/`0600` calls stay unconditional on both paths — the mode is what closes the privesc, and it is always enforced. Production is unchanged: a failed `chown` aborts the install and rolls back.

## Verification

`bash -n` clean · shellcheck 0 · shfmt clean · `11 passed, 0 failed, 11 total` on host and bash 4.4 / 5.1 / 5.2.

Permission enforcement sits inside the existing atomic-install path, so a failure rolls back rather than leaving a half-permissioned install. All three config heredocs still carry all 14 parameters.