### PR TITLE
docs: answer the questions users keep asking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Advanced temperature management for Ubiquiti UniFi OS devices with fan control.
 
 Confirmed working on: UCG-Max, UCG-Fibre, UXG-Fibre, UDM-SE, UDM-Pro-Max, UDR7, UNVR
 
+**Not supported: UniFi switches (USW line).** They run BusyBox `sh` with no bash, no
+`ubnt-systool` for temperature, and no systemd — and their fans are generally firmware
+controlled rather than exposed as writable `/sys/class/hwmon/*/pwm*`. This needs consoles
+and gateways running full UniFi OS.
+
 > This project is built and maintained independently. If it keeps your UniFi gear cool and quiet, [consider supporting it](https://ko-fi.com/H2H719VB0U).
 
 ## Features
@@ -238,6 +243,42 @@ systemctl restart fan-control.service  # Apply config changes
 # Full Removal
 /data/fan-control/uninstall.sh
 ```
+
+### Which version am I running?
+
+```bash
+cat /data/fan-control/VERSION
+journalctl -u fan-control.service | grep starting | tail -1
+# CONFIG: fan-control v1.1.1 starting
+```
+
+Neither prints anything on builds older than v1.0.0 — those predate version identity.
+
+### Updating
+
+Re-run the installer. There is no auto-update: this runs as root, and a self-updating
+root daemon is a large attack surface for a fan controller.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/iceteaSA/unifi-fan-control/main/install.sh | sudo bash
+```
+
+**Your config is preserved.** `/data/fan-control/config` is never overwritten by an
+install or upgrade — only the scripts and the service unit are replaced. No backup step
+is needed.
+
+### Does it survive a UniFi OS update?
+
+A normal firmware update, yes. A factory reset, no.
+
+UniFi OS runs root as an overlay: the firmware is a read-only lower layer, and anything
+you install lands in the upper layer. Both halves of this install live there — the
+systemd unit and `/data/fan-control` — so they share one fate. A firmware update swaps
+the lower layer and leaves the upper alone.
+
+What does remove it: factory reset, `reset2defaults`, re-adoption, or any recovery flow
+that rebuilds the overlay. If the service disappears and other things you installed went
+with it, that was the overlay rather than this script. Reinstall with the one-liner above.
 
 ## Project Structure
 - **fan-control.sh**: The main script that monitors temperature and controls fan speed

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -11,6 +11,7 @@ This guide covers common issues and their solutions for the UniFi Fan Control sy
 - [Installation Issues](#installation-issues)
 - [Performance Issues](#performance-issues)
 - [Diagnostic Commands](#diagnostic-commands)
+- [Hardware Compatibility Notes](#hardware-compatibility-notes)
 
 ---
 
@@ -533,6 +534,44 @@ If you're still experiencing issues:
 ---
 
 ## Hardware Compatibility Notes
+
+### Service disappeared after a UniFi OS update
+
+Check whether it is actually gone, or just stopped:
+
+```bash
+systemctl status fan-control.service
+ls -l /data/fan-control/ /etc/systemd/system/fan-control.service
+```
+
+If both the unit and `/data/fan-control` are missing, the overlay was rebuilt — that is a
+factory reset, `reset2defaults`, re-adoption, or a recovery flow, not a routine firmware
+update. UniFi OS keeps the firmware as a read-only lower layer and everything you install
+in an upper layer, and both halves of this install live in that upper layer. A normal
+update replaces the lower layer only.
+
+A useful tell: if other things you installed vanished at the same time, it was the
+overlay, not this project. Reinstall with the one-liner in the README; your config comes
+back only if `/data/fan-control/config` survived.
+
+### Unsupported hardware: UniFi switches (USW line)
+
+`-sh: bash: not found` on a USW means exactly what it says. Switches run BusyBox `sh`,
+not bash, and nothing is installed when this happens — it fails on the first command.
+
+Four separate things block it, not one: no bash (the daemon uses `[[ ]]`, `(( ))` and
+arrays throughout), no `ubnt-systool` for CPU temperature, no systemd, and fans that are
+typically firmware controlled rather than exposed to userspace.
+
+To check whether your device exposes fans at all:
+
+```sh
+ls /sys/class/hwmon/*/pwm* 2>/dev/null || echo "no pwm files"
+command -v ubnt-systool || echo "no ubnt-systool"
+```
+
+No output from the first means the fans are not software-controllable there, and no
+script of any kind will help.
 
 ### Different PWM Device Paths
 


### PR DESCRIPTION
Five things have now been asked in discussions and answered ad hoc each time. Putting them in the docs so they stop being asked.

Sources: #3, #6, #13, #16, #21.

## README

**Which version am I running** (#21 — *"I don't know which version I have, and I don't see any releases"*). That complaint was correct when it was written; there were no releases and no version string. Now there are both, so this documents `cat /data/fan-control/VERSION` and the startup log line, and notes that neither exists on pre-v1.0.0 builds.

**Updating** (#13, #21). Re-run the installer, no auto-update, with the reason stated: a self-updating root daemon is a large attack surface for a fan controller.

**Config preservation** (#21 — *"will it overwrite my configuration? Should I take precautions?"*). Never answered. It doesn't, and it's now stated plainly. Verified by upgrading a live UCG-Max twice today and hashing the config either side:

```
before v1.0.0:  1f7525393f17bf4d...
after  v1.0.0:  1f7525393f17bf4d...
after  v1.1.1:  1f7525393f17bf4d...
```

**Surviving a UniFi OS update** (#3, #6). Open since April, never conclusively answered — one person said they'd test it and didn't report back.

Answer: normal firmware update yes, factory reset no. UniFi OS runs root as an overlay with the firmware as a read-only lower layer; both the systemd unit and `/data/fan-control` live in the upper layer, so they share one fate. Evidence from my gateway:

```
firmware built:           2026-07-27
/mnt/.rofs mtime:         2026-07-27
fan-control config mtime: 2026-03-30   ← survived the firmware swap
```

**USW switches are not supported** (#16). The README said "UniFi OS devices", and someone with a switch reasonably assumed theirs qualified. Now stated with the reasons.

## TROUBLESHOOTING

Two new sections under Hardware Compatibility:

- **Service disappeared after an update** — how to tell an overlay rebuild from a routine update. The useful tell is whether *other* things you installed vanished too; if so it was the overlay, not this project.
- **USW switches** — `-sh: bash: not found` explained, the four independent blockers listed, and two commands to check whether a given device exposes fans to userspace at all.

Also added the Hardware Compatibility section to the table of contents, which was missing it.

## Verification

Every command documented here was run against a live UCG-Max rather than written from memory:

```
$ cat /data/fan-control/VERSION
1.1.1
$ journalctl -u fan-control.service | grep starting | tail -1
CONFIG: fan-control v1.1.1 starting
```

Docs only — no code changes. Gates green.