### PR TITLE
feat: use drive temperature as an independent PWM floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ and gateways running full UniFi OS.
   - Falls back to raw sysfs device paths when needed (UDM-SE)
   - Identifies active fans by RPM reading and write-tests each channel
   - All detected fans receive the same PWM value
+- **Drive Temperature Floor**: Raises PWM for a hot NVMe or SATA drive without changing the CPU curve
 
 ## Installation
 ```bash
@@ -92,6 +93,13 @@ MAX_PWM=255       # Maximum speed (0-255)
 MAX_PWM_STEP=25   # Maximum speed change per adjustment
                   # Note: Due to hardware limitations, actual PWM values may vary slightly from requested values
 
+# Drive Temperature Floor
+# auto detects a readable NVMe or SATA drive; false skips detection entirely
+DRIVE_TEMP_ENABLED=auto
+DRIVE_MIN_TEMP=50        # Start raising the PWM floor (°C)
+DRIVE_MAX_TEMP=70        # Reach maximum PWM (°C)
+DRIVE_CHECK_INTERVAL=60  # Drive temperature polling interval (seconds)
+
 # Advanced Tuning
 ALPHA=20          # Smoothing factor, lower values make the smoothed temp follow raw temp more closely (0-100 raw→smooth)
 DEADBAND=1        # Temperature stability threshold (°C)
@@ -149,6 +157,9 @@ STATE: TAPER→ACTIVE (67℃ ≥ 67℃)
 # Speed Changes
 SET: 55→80pwm | Reason: Ramp-up limited: 55→80pwm
 SET: 120→255pwm | Reason: EMERGENCY: Temp 86℃ ≥ 85℃
+
+# Drive Temperature Floor
+DRIVE: Detected /dev/nvme0n1 via nvme | Temp=47℃ | wctemp=83℃
 
 # Enhanced Learning System
 LEARNING: 80→85pwm (+5 (rising temp 2℃)) [Rate=7]

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -285,6 +285,29 @@ journalctl -xe
 
 ---
 
+### Drive Temperature Floor Is Active
+
+**Symptoms**: The fan runs while CPU temperature is below its activation threshold, or `DRIVE:` appears in the log.
+
+The drive floor is separate from the CPU curve. It starts at 50°C and reaches maximum PWM at 70°C by default. A device without a readable drive stays silent and keeps the existing CPU-only behavior.
+
+**Check**:
+```bash
+journalctl -u fan-control.service -n 50 | grep "DRIVE:"
+```
+
+**Tune or disable it**:
+```bash
+sudo nano /data/fan-control/config
+
+DRIVE_MIN_TEMP=55        # Start the floor later
+DRIVE_MAX_TEMP=75        # Reach maximum PWM later
+# DRIVE_TEMP_ENABLED=false  # Skip drive detection entirely
+
+sudo systemctl restart fan-control.service
+```
+
+---
 ## Configuration Issues
 
 ### Configuration Changes Not Applied

--- a/fan-control.sh
+++ b/fan-control.sh
@@ -10,6 +10,7 @@ CONFIG_FILE="${FAN_CONTROL_CONFIG_FILE:-/data/fan-control/config}"
 TEMP_STATE_FILE="${FAN_CONTROL_TEMP_STATE_FILE:-/data/fan-control/temp_state}"
 HWMON_BASE="${FAN_CONTROL_HWMON_BASE:-/sys/class/hwmon}"
 VERSION_FILE="${FAN_CONTROL_VERSION_FILE:-/data/fan-control/VERSION}"
+DRIVE_DEV_DIR="${FAN_CONTROL_DRIVE_DEV_DIR:-/dev}"
 
 # Define default configuration values
 DEFAULT_MIN_PWM=91                                    # Minimum active fan speed (0-255)
@@ -26,6 +27,10 @@ DEFAULT_MAX_PWM_STEP=25 # Max PWM change per adjustment
 DEFAULT_DEADBAND=1      # Temp stability threshold (°C)
 DEFAULT_ALPHA=20        # Smoothing factor, lower values make the smoothed temp follow raw temp more closely (0-100)
 DEFAULT_LEARNING_RATE=5 # PWM optimization step size
+DEFAULT_DRIVE_TEMP_ENABLED=auto
+DEFAULT_DRIVE_MIN_TEMP=50
+DEFAULT_DRIVE_MAX_TEMP=70
+DEFAULT_DRIVE_CHECK_INTERVAL=60
 
 # Create config file if it doesn't exist
 if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -57,6 +62,10 @@ MAX_PWM_STEP=$DEFAULT_MAX_PWM_STEP        # Max PWM change per adjustment
 DEADBAND=$DEFAULT_DEADBAND             # Temp stability threshold (°C)
 ALPHA=$DEFAULT_ALPHA               # Smoothing factor, lower values make the smoothed temp follow raw temp more closely (0-100)
 LEARNING_RATE=$DEFAULT_LEARNING_RATE        # PWM optimization step size
+DRIVE_TEMP_ENABLED=$DEFAULT_DRIVE_TEMP_ENABLED
+DRIVE_MIN_TEMP=$DEFAULT_DRIVE_MIN_TEMP
+DRIVE_MAX_TEMP=$DEFAULT_DRIVE_MAX_TEMP
+DRIVE_CHECK_INTERVAL=$DEFAULT_DRIVE_CHECK_INTERVAL
 DEFAULTS
         logger -t fan-control "FATAL: Failed to write to temporary config file"
         exit 1
@@ -108,6 +117,10 @@ check_param "MAX_PWM_STEP" "$DEFAULT_MAX_PWM_STEP" "# Max PWM change per adjustm
 check_param "DEADBAND" "$DEFAULT_DEADBAND" "# Temp stability threshold (°C)"
 check_param "ALPHA" "$DEFAULT_ALPHA" "# Smoothing factor (0-100)"
 check_param "LEARNING_RATE" "$DEFAULT_LEARNING_RATE" "# PWM optimization step size"
+check_param "DRIVE_TEMP_ENABLED" "$DEFAULT_DRIVE_TEMP_ENABLED" "# Enable drive temperature PWM floor (auto, true, false)"
+check_param "DRIVE_MIN_TEMP" "$DEFAULT_DRIVE_MIN_TEMP" "# Drive temperature where PWM floor begins (°C)"
+check_param "DRIVE_MAX_TEMP" "$DEFAULT_DRIVE_MAX_TEMP" "# Drive temperature where PWM floor reaches maximum (°C)"
+check_param "DRIVE_CHECK_INTERVAL" "$DEFAULT_DRIVE_CHECK_INTERVAL" "# Drive temperature polling interval (seconds)"
 
 # If missing parameters were found, update the config file atomically
 if [ ${#missing_params[@]} -gt 0 ]; then
@@ -189,6 +202,10 @@ MAX_PWM_STEP=$MAX_PWM_STEP        # Max PWM change per adjustment
 DEADBAND=$DEADBAND             # Temp stability threshold (°C)
 ALPHA=$ALPHA               # Smoothing factor (0-100)
 LEARNING_RATE=$LEARNING_RATE        # PWM optimization step size
+DRIVE_TEMP_ENABLED=$DRIVE_TEMP_ENABLED
+DRIVE_MIN_TEMP=$DRIVE_MIN_TEMP
+DRIVE_MAX_TEMP=$DRIVE_MAX_TEMP
+DRIVE_CHECK_INTERVAL=$DRIVE_CHECK_INTERVAL
 CONFIG
         if mv "$temp_config" "$CONFIG_FILE" 2>/dev/null; then
             logger -t fan-control "MIGRATE: Config file updated successfully"
@@ -234,6 +251,20 @@ validate_config "MAX_PWM_STEP" "$MAX_PWM_STEP" 1 50 "$DEFAULT_MAX_PWM_STEP" || c
 validate_config "DEADBAND" "$DEADBAND" 0 10 "$DEFAULT_DEADBAND" || config_changed=true
 validate_config "ALPHA" "$ALPHA" 1 99 "$DEFAULT_ALPHA" || config_changed=true
 validate_config "LEARNING_RATE" "$LEARNING_RATE" 1 20 "$DEFAULT_LEARNING_RATE" || config_changed=true
+validate_config "DRIVE_MIN_TEMP" "$DRIVE_MIN_TEMP" 30 90 "$DEFAULT_DRIVE_MIN_TEMP" || config_changed=true
+validate_config "DRIVE_MAX_TEMP" "$DRIVE_MAX_TEMP" 40 95 "$DEFAULT_DRIVE_MAX_TEMP" || config_changed=true
+validate_config "DRIVE_CHECK_INTERVAL" "$DRIVE_CHECK_INTERVAL" 15 600 "$DEFAULT_DRIVE_CHECK_INTERVAL" || config_changed=true
+if [[ "$DRIVE_TEMP_ENABLED" != "auto" && "$DRIVE_TEMP_ENABLED" != "true" && "$DRIVE_TEMP_ENABLED" != "false" ]]; then
+    logger -t fan-control "CONFIG: Invalid DRIVE_TEMP_ENABLED value: $DRIVE_TEMP_ENABLED, using default: $DEFAULT_DRIVE_TEMP_ENABLED"
+    DRIVE_TEMP_ENABLED=$DEFAULT_DRIVE_TEMP_ENABLED
+    config_changed=true
+fi
+if ((DRIVE_MAX_TEMP <= DRIVE_MIN_TEMP)); then
+    logger -t fan-control "CONFIG: DRIVE_MAX_TEMP must exceed DRIVE_MIN_TEMP, using defaults"
+    DRIVE_MIN_TEMP=$DEFAULT_DRIVE_MIN_TEMP
+    DRIVE_MAX_TEMP=$DEFAULT_DRIVE_MAX_TEMP
+    config_changed=true
+fi
 
 # If any config values were corrected, update the config file
 if [ "$config_changed" = true ]; then
@@ -258,6 +289,10 @@ MAX_PWM_STEP=$MAX_PWM_STEP        # Max PWM change per adjustment
 DEADBAND=$DEADBAND             # Temp stability threshold (°C)
 ALPHA=$ALPHA               # Smoothing factor (0-100)
 LEARNING_RATE=$LEARNING_RATE        # PWM optimization step size
+DRIVE_TEMP_ENABLED=$DRIVE_TEMP_ENABLED
+DRIVE_MIN_TEMP=$DRIVE_MIN_TEMP
+DRIVE_MAX_TEMP=$DRIVE_MAX_TEMP
+DRIVE_CHECK_INTERVAL=$DRIVE_CHECK_INTERVAL
 CONFIG
         logger -t fan-control "ERROR: Failed to write to temporary config file"
         # Continue with current in-memory values, but don't update the file
@@ -422,6 +457,14 @@ SMOOTHED_TEMP=50     # Current smoothed temperature
 LAST_ADJUSTMENT=0    # Timestamp of last PWM optimization
 LAST_AVG_TEMP=0      # Previous temperature (for deadband calculations)
 TEMP_READ_FAILURES=0 # Track consecutive temperature reading failures
+DRIVE_TEMP_AVAILABLE=false
+DRIVE_DEVICE=""
+DRIVE_METHOD=""
+DRIVE_TEMP=0
+DRIVE_WARNING_TEMP="unknown"
+DRIVE_PWM_FLOOR=0
+DRIVE_LAST_CHECK=0
+DRIVE_READ_FAILURE_LOGGED=false
 
 # Function to safely write to a file using atomic operations
 atomic_write_file() {
@@ -542,6 +585,139 @@ calculate_speed() {
     echo $speed
 }
 
+json_number() {
+    local json="$1"
+    local field="$2"
+
+    printf '%s\n' "$json" | sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\\([0-9][0-9]*\\).*/\\1/p" | sed -n '1p'
+}
+
+read_nvme_temperature() {
+    local device="$1"
+    local smart_log
+    local raw_temp
+    local controller
+    local warning_temp
+
+    smart_log=$(nvme smart-log -o json "$device" 2>/dev/null) || return 1
+    raw_temp=$(json_number "$smart_log" "temperature")
+    [[ "$raw_temp" =~ ^[0-9]+$ ]] || return 1
+
+    # nvme-cli reports SMART temperatures in Kelvin; smartctl uses Celsius.
+    DRIVE_READ_TEMP=$((raw_temp - 273))
+    ((DRIVE_READ_TEMP >= 0 && DRIVE_READ_TEMP <= 120)) || return 1
+
+    controller=$(nvme id-ctrl -o json "$device" 2>/dev/null || true)
+    warning_temp=$(json_number "$controller" "wctemp")
+    if [[ "$warning_temp" =~ ^[0-9]+$ ]]; then
+        if ((warning_temp >= 273)); then
+            warning_temp=$((warning_temp - 273))
+        fi
+        DRIVE_WARNING_TEMP=$warning_temp
+    else
+        DRIVE_WARNING_TEMP="unknown"
+    fi
+}
+
+read_smartctl_temperature() {
+    local device="$1"
+    local smart_log
+    local raw_temp
+    local warning_temp
+
+    smart_log=$(smartctl -j -A "$device" 2>/dev/null) || return 1
+    raw_temp=$(json_number "$smart_log" "current")
+    [[ "$raw_temp" =~ ^[0-9]+$ ]] || return 1
+    ((raw_temp >= 0 && raw_temp <= 120)) || return 1
+
+    DRIVE_READ_TEMP=$raw_temp
+    warning_temp=$(json_number "$smart_log" "warning")
+    if [[ "$warning_temp" =~ ^[0-9]+$ ]]; then
+        DRIVE_WARNING_TEMP=$warning_temp
+    else
+        DRIVE_WARNING_TEMP="unknown"
+    fi
+}
+
+calculate_drive_pwm_floor() {
+    local drive_range=$((DRIVE_MAX_TEMP - DRIVE_MIN_TEMP))
+
+    if ((DRIVE_TEMP <= DRIVE_MIN_TEMP)); then
+        DRIVE_PWM_FLOOR=0
+    elif ((DRIVE_TEMP >= DRIVE_MAX_TEMP)); then
+        DRIVE_PWM_FLOOR=$MAX_PWM
+    else
+        DRIVE_PWM_FLOOR=$((MIN_PWM + ((DRIVE_TEMP - DRIVE_MIN_TEMP) * (MAX_PWM - MIN_PWM) / drive_range)))
+    fi
+}
+
+detect_drive_temperature() {
+    local device
+    local device_found=false
+
+    [[ "$DRIVE_TEMP_ENABLED" != "false" ]] || return
+
+    for device in "$DRIVE_DEV_DIR"/nvme?n? "$DRIVE_DEV_DIR"/sd?; do
+        [[ -e "$device" ]] || continue
+        device_found=true
+
+        if read_nvme_temperature "$device"; then
+            DRIVE_DEVICE=$device
+            DRIVE_METHOD="nvme"
+        elif read_smartctl_temperature "$device"; then
+            DRIVE_DEVICE=$device
+            DRIVE_METHOD="smartctl"
+        else
+            continue
+        fi
+
+        DRIVE_TEMP_AVAILABLE=true
+        DRIVE_TEMP=$DRIVE_READ_TEMP
+        calculate_drive_pwm_floor
+        DRIVE_LAST_CHECK=$(date +%s)
+        logger -t fan-control "DRIVE: Detected ${DRIVE_DEVICE} via ${DRIVE_METHOD} | Temp=${DRIVE_TEMP}°C | wctemp=${DRIVE_WARNING_TEMP}°C"
+        return
+    done
+
+    if [[ "$device_found" = true ]]; then
+        logger -t fan-control "DRIVE: No readable drive temperature source found; feature disabled"
+    fi
+}
+
+update_drive_temperature() {
+    local now
+    local read_ok=false
+
+    [[ "$DRIVE_TEMP_AVAILABLE" = true ]] || return
+    now=$(date +%s)
+    if ((now - DRIVE_LAST_CHECK < DRIVE_CHECK_INTERVAL)); then
+        return
+    fi
+    DRIVE_LAST_CHECK=$now
+
+    if [[ "$DRIVE_METHOD" = "nvme" ]]; then
+        if read_nvme_temperature "$DRIVE_DEVICE"; then
+            read_ok=true
+        fi
+    else
+        if read_smartctl_temperature "$DRIVE_DEVICE"; then
+            read_ok=true
+        fi
+    fi
+
+    if [[ "$read_ok" = true ]]; then
+        DRIVE_TEMP=$DRIVE_READ_TEMP
+        calculate_drive_pwm_floor
+        DRIVE_READ_FAILURE_LOGGED=false
+    else
+        DRIVE_PWM_FLOOR=0
+        if [[ "$DRIVE_READ_FAILURE_LOGGED" = false ]]; then
+            logger -t fan-control "DRIVE: ${DRIVE_DEVICE} read failed; floor disabled"
+            DRIVE_READ_FAILURE_LOGGED=true
+        fi
+    fi
+}
+
 # Speed control with logging
 set_fan_speed() {
     local new_speed=$1
@@ -571,6 +747,17 @@ set_fan_speed() {
         # Enforce MIN/MAX only in active states
         new_speed=$((new_speed > MAX_PWM ? MAX_PWM : new_speed))
         new_speed=$((new_speed < MIN_PWM ? MIN_PWM : new_speed))
+    fi
+
+    # The floor follows the OFF override so a hot drive can still start a cool CPU's fan.
+    if ((DRIVE_PWM_FLOOR > new_speed)); then
+        if ((DRIVE_PWM_FLOOR > LAST_PWM + MAX_PWM_STEP)); then
+            new_speed=$((LAST_PWM + MAX_PWM_STEP))
+            reason="Drive floor ramp-up: ${LAST_PWM}→${new_speed}pwm"
+        else
+            new_speed=$DRIVE_PWM_FLOOR
+            reason="Drive temperature floor: ${DRIVE_TEMP}°C"
+        fi
     fi
 
     if [[ "$new_speed" -ne "$LAST_PWM" ]]; then
@@ -673,6 +860,7 @@ set_fan_speed() {
 ###[ STATE MANAGEMENT ]########################################################
 update_fan_state() {
     get_smoothed_temp
+    update_drive_temperature
     local avg_temp=$SMOOTHED_TEMP
     local now
     now=$(date +%s)
@@ -724,6 +912,8 @@ update_fan_state() {
                     state_transition="OFF→ACTIVE (${avg_temp}°C ≥ ${FAN_ACTIVATION_TEMP}°C)"
                     CURRENT_STATE=$STATE_ACTIVE
                     set_fan_speed "$OPTIMAL_PWM"
+                else
+                    set_fan_speed 0
                 fi
                 ;;
 
@@ -801,6 +991,7 @@ fi
 logger -t fan-control "CONFIG: fan-control v${FAN_CONTROL_VERSION} starting"
 logger -t fan-control "START: Optimal=${OPTIMAL_PWM}pwm | Config: MIN=${MIN_TEMP}°C, MAX=${MAX_TEMP}°C, HYST=${HYSTERESIS}°C"
 
+detect_drive_temperature
 get_smoothed_temp
 if ((SMOOTHED_TEMP >= FAN_ACTIVATION_TEMP)); then
     logger -t fan-control "COLDSTART: Initial temp ${SMOOTHED_TEMP}°C ≥ ${FAN_ACTIVATION_TEMP}°C"

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -36,6 +36,9 @@ setup_sandbox() {
     export FAN_CONTROL_OPTIMAL_PWM_FILE="$SANDBOX/optimal_pwm"
     export FAN_CONTROL_HWMON_BASE="$SANDBOX/hwmon"
     export FAN_CONTROL_VERSION_FILE="$SANDBOX/VERSION"
+    export FAN_CONTROL_DRIVE_DEV_DIR="$SANDBOX/drives"
+
+    mkdir -p "$FAN_CONTROL_DRIVE_DEV_DIR"
 
     # Build fake hwmon tree — one device with one PWM channel
     local hwmon_dir="$SANDBOX/hwmon/hwmon0"
@@ -75,6 +78,31 @@ STUB
 echo "$@" >> "${SANDBOX:-/tmp}/syslog"
 STUB
     chmod +x "$SANDBOX/bin/logger"
+
+    # Stubs: drive tools read controlled JSON fixtures or fail when requested.
+    cat >"$SANDBOX/bin/nvme" <<'STUB'
+#!/usr/bin/env bash
+echo "nvme $*" >> "${SANDBOX:-/tmp}/drive_calls"
+if [[ -f "${SANDBOX:-/tmp}/nvme_fail" ]]; then
+    exit 1
+fi
+response_file="${SANDBOX:-/tmp}/nvme_response"
+[[ -f "$response_file" ]] || exit 1
+cat "$response_file"
+STUB
+    chmod +x "$SANDBOX/bin/nvme"
+
+    cat >"$SANDBOX/bin/smartctl" <<'STUB'
+#!/usr/bin/env bash
+echo "smartctl $*" >> "${SANDBOX:-/tmp}/drive_calls"
+if [[ -f "${SANDBOX:-/tmp}/smartctl_fail" ]]; then
+    exit 1
+fi
+response_file="${SANDBOX:-/tmp}/smartctl_response"
+[[ -f "$response_file" ]] || exit 1
+cat "$response_file"
+STUB
+    chmod +x "$SANDBOX/bin/smartctl"
 
     # Stub: sleep — accelerates daemon loop by sleeping 0.05s
     cat >"$SANDBOX/bin/sleep" <<STUB

--- a/tests/test_config_bootstrap.sh
+++ b/tests/test_config_bootstrap.sh
@@ -35,6 +35,7 @@ declare -a required_params=(
     "MIN_PWM" "MAX_PWM" "MIN_TEMP" "MAX_TEMP" "HYSTERESIS"
     "CHECK_INTERVAL" "TAPER_MINS" "FAN_PWM_AUTODETECT" "FAN_PWM_DEVICE"
     "OPTIMAL_PWM_FILE" "MAX_PWM_STEP" "DEADBAND" "ALPHA" "LEARNING_RATE"
+    "DRIVE_TEMP_ENABLED" "DRIVE_MIN_TEMP" "DRIVE_MAX_TEMP" "DRIVE_CHECK_INTERVAL"
 )
 for param in "${required_params[@]}"; do
     if ! grep -q "^${param}=" "$SANDBOX/config" 2>/dev/null; then
@@ -42,7 +43,7 @@ for param in "${required_params[@]}"; do
     fi
 done
 
-echo "  ✓ Scenario ${scenario}: Fresh config created with all 14 parameters"
+echo "  ✓ Scenario ${scenario}: Fresh config created with all 18 parameters"
 
 stop_daemon
 cleanup_sandbox
@@ -118,6 +119,76 @@ fi
 assert_eq "$(stat -c%a "$SANDBOX/config")" "600" "re-appended config mode: "
 
 echo "  ✓ Scenario ${scenario}: Missing parameters re-appended"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 4: migration rewrite preserves drive parameters ─────────────────
+scenario=$((scenario + 1))
+setup_sandbox
+
+cat >"$SANDBOX/config" <<EOF
+MIN_PWM=91
+MAX_PWM=255
+MIN_TEMP=60
+MAX_TEMP=85
+HYSTERESIS=5
+CHECK_INTERVAL=15
+TAPER_MINS=90
+FAN_PWM_AUTODETECT=true
+FAN_PWM_DEVICE="/stale/raw/pwm1"
+OPTIMAL_PWM_FILE="$SANDBOX/optimal_pwm"
+MAX_PWM_STEP=25
+DEADBAND=1
+ALPHA=20
+LEARNING_RATE=5
+DRIVE_TEMP_ENABLED=auto
+DRIVE_MIN_TEMP=50
+DRIVE_MAX_TEMP=70
+DRIVE_CHECK_INTERVAL=60
+EOF
+
+start_daemon
+for param in MIN_PWM MAX_PWM MIN_TEMP MAX_TEMP HYSTERESIS CHECK_INTERVAL TAPER_MINS FAN_PWM_AUTODETECT FAN_PWM_DEVICE OPTIMAL_PWM_FILE MAX_PWM_STEP DEADBAND ALPHA LEARNING_RATE DRIVE_TEMP_ENABLED DRIVE_MIN_TEMP DRIVE_MAX_TEMP DRIVE_CHECK_INTERVAL; do
+    grep -q "^${param}=" "$SANDBOX/config" || fail "migration rewrite removed ${param}"
+done
+
+echo "  ✓ Scenario ${scenario}: Migration rewrite preserves all 18 parameters"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 5: corrected-value rewrite preserves drive parameters ───────────
+scenario=$((scenario + 1))
+setup_sandbox
+
+cat >"$SANDBOX/config" <<EOF
+MIN_PWM=999
+MAX_PWM=255
+MIN_TEMP=60
+MAX_TEMP=85
+HYSTERESIS=5
+CHECK_INTERVAL=15
+TAPER_MINS=90
+FAN_PWM_AUTODETECT=true
+FAN_PWM_DEVICE="$SANDBOX/hwmon/hwmon0/pwm1"
+OPTIMAL_PWM_FILE="$SANDBOX/optimal_pwm"
+MAX_PWM_STEP=25
+DEADBAND=1
+ALPHA=20
+LEARNING_RATE=5
+DRIVE_TEMP_ENABLED=auto
+DRIVE_MIN_TEMP=50
+DRIVE_MAX_TEMP=70
+DRIVE_CHECK_INTERVAL=60
+EOF
+
+start_daemon
+for param in MIN_PWM MAX_PWM MIN_TEMP MAX_TEMP HYSTERESIS CHECK_INTERVAL TAPER_MINS FAN_PWM_AUTODETECT FAN_PWM_DEVICE OPTIMAL_PWM_FILE MAX_PWM_STEP DEADBAND ALPHA LEARNING_RATE DRIVE_TEMP_ENABLED DRIVE_MIN_TEMP DRIVE_MAX_TEMP DRIVE_CHECK_INTERVAL; do
+    grep -q "^${param}=" "$SANDBOX/config" || fail "corrected-value rewrite removed ${param}"
+done
+
+echo "  ✓ Scenario ${scenario}: Corrected-value rewrite preserves all 18 parameters"
 
 stop_daemon
 cleanup_sandbox

--- a/tests/test_drive_temp_floor.sh
+++ b/tests/test_drive_temp_floor.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+###############################################################################
+# Drive temperature floor tests: silent absence, unit conversion, and failures.
+###############################################################################
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tests/lib/harness.sh
+source "$SCRIPT_DIR/lib/harness.sh"
+trap teardown_sandbox EXIT
+
+declare -i scenario=0
+
+assert_no_drive_logs() {
+    local logs="$1"
+    if grep -q 'DRIVE:' <<<"$logs" || grep -q 'DETECT:.*drive' <<<"$logs"; then
+        fail "no-drive startup emitted drive detection logs"
+    fi
+}
+
+prepare_second_start() {
+    start_daemon
+    stop_daemon
+    : >"$SANDBOX/syslog"
+}
+
+# ── Scenario 1: no drive is as silent as an explicitly disabled feature ──────
+scenario=$((scenario + 1))
+setup_sandbox
+echo "45" >"$SANDBOX/cputemp"
+prepare_second_start
+echo 'DRIVE_TEMP_ENABLED=false' >>"$SANDBOX/config"
+start_daemon
+/bin/sleep 1
+disabled_pwm=$(get_pwm)
+stop_daemon
+cleanup_sandbox
+
+setup_sandbox
+echo "45" >"$SANDBOX/cputemp"
+prepare_second_start
+for param in DRIVE_TEMP_ENABLED DRIVE_MIN_TEMP DRIVE_MAX_TEMP DRIVE_CHECK_INTERVAL; do
+    grep -q "^${param}=" "$SANDBOX/config" || fail "fresh config missing ${param}"
+done
+start_daemon
+/bin/sleep 1
+auto_logs=$(cat "$SANDBOX/syslog")
+auto_pwm=$(get_pwm)
+assert_no_drive_logs "$auto_logs"
+assert_eq "$auto_pwm" "$disabled_pwm" "no-drive PWM must match disabled feature: "
+[[ ! -s "$SANDBOX/drive_calls" ]] || fail "no-drive startup invoked a drive tool"
+
+echo "  ✓ Scenario ${scenario}: no drive is silent and PWM-identical to disabled"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 2: a hot drive lifts PWM while the CPU remains in OFF ───────────
+scenario=$((scenario + 1))
+setup_sandbox
+echo "45" >"$SANDBOX/cputemp"
+touch "$FAN_CONTROL_DRIVE_DEV_DIR/nvme0n1"
+cat >"$SANDBOX/nvme_response" <<'JSON'
+{"temperature":330,"wctemp":83}
+JSON
+
+start_daemon
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0 10 || fail "hot drive did not lift PWM from OFF"
+assert_contains "$(cat "$SANDBOX/syslog")" "DRIVE:" "hot drive should be logged: "
+
+echo "  ✓ Scenario ${scenario}: hot drive lifts PWM from OFF"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 3: NVMe JSON Kelvin 320 converts to a cool 47°C ────────────────
+scenario=$((scenario + 1))
+setup_sandbox
+echo "45" >"$SANDBOX/cputemp"
+touch "$FAN_CONTROL_DRIVE_DEV_DIR/nvme0n1"
+cat >"$SANDBOX/nvme_response" <<'JSON'
+{"temperature":320,"wctemp":83}
+JSON
+
+start_daemon
+/bin/sleep 1
+assert_eq "$(get_pwm)" "0" "NVMe Kelvin 320 must convert to cool 47°C: "
+assert_contains "$(cat "$SANDBOX/syslog")" "47°C" "NVMe Kelvin conversion should log 47°C: "
+
+echo "  ✓ Scenario ${scenario}: NVMe 320K converts to 47°C"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 4: smartctl JSON Celsius 47 stays at 47°C ─────────────────────
+scenario=$((scenario + 1))
+setup_sandbox
+echo "45" >"$SANDBOX/cputemp"
+touch "$FAN_CONTROL_DRIVE_DEV_DIR/nvme0n1"
+touch "$SANDBOX/nvme_fail"
+cat >"$SANDBOX/smartctl_response" <<'JSON'
+{"temperature":{"current":47,"warning":83}}
+JSON
+
+start_daemon
+/bin/sleep 1
+assert_eq "$(get_pwm)" "0" "smartctl Celsius 47 must remain cool: "
+assert_contains "$(cat "$SANDBOX/syslog")" "47°C" "smartctl Celsius value should log 47°C: "
+
+echo "  ✓ Scenario ${scenario}: smartctl 47°C remains 47°C"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 5: a cool drive does not override the CPU curve ─────────────────
+scenario=$((scenario + 1))
+setup_sandbox
+echo "75" >"$SANDBOX/cputemp"
+touch "$FAN_CONTROL_DRIVE_DEV_DIR/nvme0n1"
+cat >"$SANDBOX/nvme_response" <<'JSON'
+{"temperature":320,"wctemp":83}
+JSON
+
+start_daemon
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0 10 || fail "hot CPU should control PWM with cool drive"
+
+echo "  ✓ Scenario ${scenario}: cool drive leaves hot CPU in control"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 6: a failed read drops the floor without forcing MAX_PWM ────────
+scenario=$((scenario + 1))
+setup_sandbox
+echo "45" >"$SANDBOX/cputemp"
+touch "$FAN_CONTROL_DRIVE_DEV_DIR/nvme0n1"
+cat >"$SANDBOX/nvme_response" <<'JSON'
+{"temperature":330,"wctemp":83}
+JSON
+cat >>"$SANDBOX/config" <<'CONFIG'
+DRIVE_CHECK_INTERVAL=15
+CONFIG
+
+start_daemon
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0 10 || fail "hot drive should establish a floor"
+touch "$SANDBOX/nvme_fail"
+wait_for_log "DRIVE:.*read failed" 20 || fail "failed drive read was not logged"
+wait_for_file_value "$SANDBOX/hwmon/hwmon0/pwm1" "0" 10 || fail "failed drive read should drop floor"
+assert_eq "$(get_pwm)" "0" "failed drive read must not force MAX_PWM: "
+
+echo "  ✓ Scenario ${scenario}: drive read failure drops floor without MAX_PWM"
+
+stop_daemon
+cleanup_sandbox
+
+echo "  All ${scenario} drive temperature floor scenarios passed."

--- a/tests/test_drive_temp_floor_hot_off.sh
+++ b/tests/test_drive_temp_floor_hot_off.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+###############################################################################
+# Drive temperature floor test: hot drive must lift PWM from the OFF state.
+###############################################################################
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tests/lib/harness.sh
+source "$SCRIPT_DIR/lib/harness.sh"
+trap teardown_sandbox EXIT
+
+setup_sandbox
+echo "45" >"$SANDBOX/cputemp"
+touch "$FAN_CONTROL_DRIVE_DEV_DIR/nvme0n1"
+cat >"$SANDBOX/nvme_response" <<'JSON'
+{"temperature":330,"wctemp":83}
+JSON
+
+start_daemon
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0 10 || fail "hot drive did not lift PWM from OFF"
+
+echo "  ✓ Hot drive lifted PWM from OFF"


### PR DESCRIPTION
Answers #11 (@alexkush2): SSD in a UCG-Max ran 55 °C, dropped to 40 °C once the fan ran at minimum, and he asked for drive temperature as a second input. Also relevant to the UNVR reports in #6 and #15, where an SSD upgrade pushed the device to 80–85 °C.

Draft — the code is verified but the feature has not run on hardware with a hot drive yet. See "Not verified" at the bottom.

## Why not `max(cpu, ssd)`

The obvious implementation is wrong, and quietly so.

The existing curve is CPU-calibrated: activation 65 °C, maximum 85 °C. Measured on a UCG-Max just now — CPU 68.5 °C, SSD 47 °C, and the drive's own warning threshold is 83 °C. Feed drive temperature into the CPU curve and nothing happens until the drive reaches 65 °C, by which point it is most of the way to its warning. alexkush2's 55 °C complaint would register as stone cold.

So drive temperature never enters `calculate_speed`. It produces an independent **minimum PWM** that the result is clamped up to. The CPU curve is untouched; whichever demands more wins.

```
drive_temp <= DRIVE_MIN_TEMP   ->  floor 0        (no influence)
drive_temp >= DRIVE_MAX_TEMP   ->  floor MAX_PWM
between                        ->  linear MIN_PWM..MAX_PWM
```

Defaults 50 → 70 °C. 50 gives action at alexkush2's reported 55 °C; 70 reaches full speed before consumer NVMe throttling and well below the 83 °C warning.

## Silent on devices without a drive

Most UniFi devices have no drive, and they should not pay for this feature in log noise or probe overhead. Detection runs once at startup:

| Situation | Behaviour |
|---|---|
| No `/dev/nvme*` and no `/dev/sd*` | Silent. No log line, no tool invoked, PWM behaviour unchanged. |
| Drive present, probe fails | One `DRIVE:` line, feature off, never probed again |
| Drive present and readable | One `DRIVE:` line naming device, method and `wctemp` |

Test asserts *zero* `DRIVE:`/`DETECT:` lines and that no drive tool was invoked at all, so a well-meaning "no drive found" line fails the suite.

## Three traps, each mutation-checked

| Mutation | Test response |
|---|---|
| Make the no-drive log unconditional | `FAIL: no-drive startup emitted drive detection logs` |
| Move the floor *before* the OFF-state override | `FAIL: hot drive did not lift PWM from OFF` |
| Drop the Kelvin conversion | `FAIL: hot drive did not lift PWM from OFF` |

The second is the one worth explaining. `set_fan_speed()` forces PWM 0 in `STATE_OFF` — which is exactly the cool-CPU/hot-drive case this feature exists for. A floor applied before that override is dead code that looks correct. It is applied after (`fan-control.sh:752-761`), and is the only thing permitted to lift PWM out of OFF. Ramp limits still apply on the way up; a hot drive is not an emergency.

The third: `nvme smart-log -o json` reports **Kelvin** (`"temperature" : 320`), `smartctl -j` reports **Celsius** (`"temperature": 47`). Same field name, different units. Getting it backwards yields a 273 °C reading that pins the fan to maximum permanently. Both paths are tested with those exact values.

## Other behaviour

- **Poll cadence is separate** from the 15 s control loop (`DRIVE_CHECK_INTERVAL=60`). NVMe does not care, but on a UNVR with spinning disks a 15 s SMART poll can prevent spin-down.
- **A failed drive read never forces MAX_PWM.** The CPU sensor fail-safe does that deliberately after 3 failures; the drive path must not, because the CPU sensor remains the authority on whether the device is actually hot. On failure: log once, drop the floor to 0, continue.
- Four new parameters in all three config heredocs (18 each), with `check_param` and `validate_config` entries. Always written, so a user who later fits an SSD gets the feature without editing config — the silence is a runtime property, not a config-file one.

## Verification

`bash -n` clean · shellcheck 0 (v0.11.0) · shfmt clean (v3.13.1) · `13 passed, 0 failed` on host and bash 4.4 / 5.1 / 5.2.

The JSON parser was run against real output captured from a live UCG-Max rather than only against fixtures:

```
parsed temperature=319 -> 46C     (drive reported 47C moments earlier)
parsed wctemp=356     -> 83C     (matches the drive's stated warning threshold)
```

The 47 → 46 difference is the drive genuinely cooling by one degree between the two calls, not a parse error — the captured JSON contains `319`. Argument order (`nvme smart-log -o json <device>`) was confirmed against the real nvme-cli on the device.

## Not verified

**No hardware test with a hot drive.** The floor's effect on a real fan is unproven — the UCG-Max here idles at 47 °C, which is below the 50 °C threshold, so the floor stays at 0 and the feature is inert. Everything above is code-level and sandboxed evidence.

Also untested: SATA drives via `smartctl` (this device has only NVMe, and the SATA path is exercised solely through stubs), and multi-drive devices such as the UNVR — detection takes the first readable drive rather than the hottest.

Draft until at least the first of those is closed.