### PR TITLE
fix: diagnose install failures precisely and harden the tar header walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the UCG Max Fan Control project will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+* Diagnose failed verified-release downloads by curl failure class. DNS failures
+  now name the failing host and explain GitHub's release-asset redirect.
+* Add a tag-scoped `FAN_CONTROL_ALLOW_UNVERIFIED` fallback for a verified download
+  that cannot complete. The fallback is explicit and still validates its payload.
+
 ## [1.2.0](https://github.com/iceteaSA/unifi-fan-control/compare/v1.1.1...v1.2.0) (2026-08-09)
 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ curl -fsSL https://raw.githubusercontent.com/iceteaSA/unifi-fan-control/main/ins
 `FAN_CONTROL_VERSION` accepts `v1.2.0` or `1.2.0`. Pinned installs verify the
 matching release tarball before replacing installed files.
 
+### Release Download DNS Failures
+
+GitHub redirects verified release downloads from `github.com` to
+`release-assets.githubusercontent.com`. Both names must resolve. If the installer
+names `release-assets.githubusercontent.com`, fix the device's DNS resolver or
+allow that host first. That is a resolver failure, not a broken installer or
+release.
+
+If the installer reports that `raw.githubusercontent.com` is reachable and the
+resolver cannot be fixed immediately, a one-time fallback is available for one
+specific tag:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/iceteaSA/unifi-fan-control/v1.2.0/install.sh | sudo FAN_CONTROL_ALLOW_UNVERIFIED=v1.2.0 bash
+```
+
+This bypasses SHA256 verification for that install. It still validates the
+downloaded files before writing them, but it is not the normal or preferred path.
+`FAN_CONTROL_ALLOW_UNVERIFIED` must exactly match the tag being installed.
+
 ### Using a Different Branch
 For development builds:
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -408,6 +408,27 @@ files unchanged. Check the installed identity with:
 cat /data/fan-control/VERSION
 ```
 
+### DNS Failure Resolving `release-assets.githubusercontent.com`
+
+GitHub redirects release downloads from `github.com` to
+`release-assets.githubusercontent.com`. A verified install needs both names to
+resolve. If the installer names `release-assets.githubusercontent.com`, fix the
+device's resolver, DNS filter, or stale cache. The installer and release are not
+the cause.
+
+The installer also checks `raw.githubusercontent.com` and reports whether it is
+reachable. If it is reachable and the resolver cannot be fixed immediately, use
+the exact tag from the error message to opt in to the fallback:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/iceteaSA/unifi-fan-control/v1.2.0/install.sh | sudo FAN_CONTROL_ALLOW_UNVERIFIED=v1.2.0 bash
+```
+
+This is a deliberate one-install exception. It downloads tagged files from
+`raw.githubusercontent.com` and skips SHA256 verification; it does not weaken the
+file-size, syntax, or payload validation checks. Fixing DNS and using the verified
+release path remains the right fix.
+
 ### Branch-Specific Installation Fails
 
 **Issue**: Can't install from a specific branch

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,7 @@ WORK_DIR="$(mktemp -d)"
 RESOLVED_VERSION=""
 INSTALL_SOURCE=""
 SERVICE_WAS_ACTIVE=0
+UNVERIFIED_RELEASE=0
 DESTINATIONS=()
 NEW_FILES=()
 BACKUPS=()
@@ -202,6 +203,129 @@ copy_local_payload() {
     return 0
 }
 
+validate_unverified_consent() {
+    local tag="$1"
+    local allowed_tag="${FAN_CONTROL_ALLOW_UNVERIFIED:-}"
+
+    if [[ -z "$allowed_tag" ]]; then
+        return 0
+    fi
+    if [[ "$allowed_tag" != v* ]] || ! is_semver "${allowed_tag#v}"; then
+        fail "FAN_CONTROL_ALLOW_UNVERIFIED must name a release tag such as $tag"
+    fi
+    if [[ "$allowed_tag" != "$tag" ]]; then
+        fail "FAN_CONTROL_ALLOW_UNVERIFIED must match requested release tag: $tag"
+    fi
+}
+
+probe_unverified_fallback() {
+    local tag="$1"
+    local fallback_url="https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$tag/VERSION"
+    local fallback_error="$WORK_DIR/fallback-curl-error"
+    local fallback_status
+
+    if curl -fsSL --connect-timeout 10 --max-time 20 -o /dev/null "$fallback_url" 2>"$fallback_error"; then
+        echo "Error: Unverified fallback host raw.githubusercontent.com is reachable for $tag" >&2
+        return 0
+    else
+        fallback_status=$?
+    fi
+
+    if ((fallback_status == 22)); then
+        echo "Error: Unverified fallback host raw.githubusercontent.com responded, but the VERSION request failed (curl exit 22)" >&2
+    else
+        echo "Error: Unverified fallback host raw.githubusercontent.com is not reachable for $tag (curl exit $fallback_status)" >&2
+    fi
+    return 1
+}
+
+diagnose_release_download_failure() {
+    local tag="$1"
+    local curl_status="$2"
+    local curl_error="$3"
+    local failed_host
+    local http_status
+
+    if ((curl_status == 6)); then
+        failed_host=$(sed -n 's/.*Could not resolve host: \([^[:space:]]*\).*/\1/p' "$curl_error")
+        if [[ "$failed_host" == "release-assets.githubusercontent.com" ]]; then
+            echo "Error: DNS lookup failed for release-assets.githubusercontent.com while downloading release $tag" >&2
+            echo "Error: GitHub redirects release downloads to release-assets.githubusercontent.com" >&2
+            echo "Error: This is a resolver problem, not a fault in the installer or release" >&2
+        elif [[ -n "$failed_host" ]]; then
+            echo "Error: DNS lookup failed for $failed_host while downloading release $tag" >&2
+            echo "Error: This is a resolver problem, not a fault in the installer or release" >&2
+        else
+            echo "Error: DNS lookup failed while downloading release $tag (curl exit 6)" >&2
+            echo "Error: curl did not identify the host, so the installer cannot name it" >&2
+        fi
+    else
+        case "$curl_status" in
+            22)
+                http_status=$(sed -n 's/.*error: \([0-9][0-9][0-9]\).*/\1/p' "$curl_error")
+                if [[ -n "$http_status" ]]; then
+                    echo "Error: HTTP error $http_status while downloading release $tag" >&2
+                else
+                    echo "Error: HTTP error while downloading release $tag (curl exit 22)" >&2
+                fi
+                ;;
+            28)
+                echo "Error: Connection timed out while downloading release $tag (curl exit 28)" >&2
+                ;;
+            35 | 51 | 58 | 59 | 60 | 77)
+                echo "Error: TLS error while downloading release $tag (curl exit $curl_status)" >&2
+                ;;
+            *)
+                echo "Error: Network failure while downloading release $tag (curl exit $curl_status)" >&2
+                ;;
+        esac
+        echo "Error: This is not a DNS resolution failure" >&2
+    fi
+
+    probe_unverified_fallback "$tag" || true
+}
+
+download_unverified_payload() {
+    local ref="$1"
+    local source="$2"
+    local expected_version="${3:-}"
+    local filename
+    local payload_dir="$WORK_DIR/payload"
+    local base_url="https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$ref"
+
+    mkdir -p "$payload_dir"
+    for filename in "${PAYLOAD_FILES[@]}"; do
+        if ! curl -fsSL "$base_url/$filename" -o "$payload_dir/$filename"; then
+            fail "Failed to download $filename from $source"
+        fi
+    done
+
+    validate_payload "$payload_dir" "$expected_version"
+    INSTALL_SOURCE="$source"
+}
+
+download_unverified_release() {
+    local tag="$1"
+
+    echo "WARNING: SHA256 verification will be skipped for release $tag" >&2
+    download_unverified_payload "$tag" "unverified release $tag" "${tag#v}"
+    UNVERIFIED_RELEASE=1
+}
+
+handle_verified_download_failure() {
+    local tag="$1"
+    local curl_status="$2"
+    local curl_error="$3"
+
+    diagnose_release_download_failure "$tag" "$curl_status" "$curl_error"
+    if [[ -z "${FAN_CONTROL_ALLOW_UNVERIFIED:-}" ]]; then
+        echo "Error: The verified download failed. To install $tag without SHA256 verification, run:" >&2
+        echo "curl -fsSL https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$tag/install.sh | sudo FAN_CONTROL_ALLOW_UNVERIFIED=$tag bash" >&2
+        exit 1
+    fi
+    download_unverified_release "$tag"
+}
+
 download_verified_release() {
     local tag="$1"
     local archive_name="unifi-fan-control-${tag}.tar.gz"
@@ -211,12 +335,24 @@ download_verified_release() {
     local expected_checksum
     local actual_checksum
     local filename
+    local curl_error="$WORK_DIR/release-curl-error"
+    local curl_status
 
-    if ! curl -fsSL --max-filesize "$MAX_ARCHIVE_BYTES" "$RELEASE_BASE_URL/download/$tag/$archive_name" -o "$archive"; then
-        fail "Failed to download release archive: $tag"
+    validate_unverified_consent "$tag"
+
+    if curl -fsSL --max-filesize "$MAX_ARCHIVE_BYTES" "$RELEASE_BASE_URL/download/$tag/$archive_name" -o "$archive" 2>"$curl_error"; then
+        :
+    else
+        curl_status=$?
+        handle_verified_download_failure "$tag" "$curl_status" "$curl_error"
+        return 0
     fi
-    if ! curl -fsSL "$RELEASE_BASE_URL/download/$tag/SHA256SUMS" -o "$checksum_file"; then
-        fail "Failed to download release checksums: $tag"
+    if curl -fsSL "$RELEASE_BASE_URL/download/$tag/SHA256SUMS" -o "$checksum_file" 2>"$curl_error"; then
+        :
+    else
+        curl_status=$?
+        handle_verified_download_failure "$tag" "$curl_status" "$curl_error"
+        return 0
     fi
 
     if ! expected_checksum=$(awk -v filename="$archive_name" '
@@ -256,20 +392,9 @@ download_verified_release() {
 
 download_branch_payload() {
     local branch="$1"
-    local filename
-    local payload_dir="$WORK_DIR/payload"
-    local base_url="https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$branch"
 
     echo "WARNING: branch install is unverified: $branch"
-    mkdir -p "$payload_dir"
-    for filename in "${PAYLOAD_FILES[@]}"; do
-        if ! curl -fsSL "$base_url/$filename" -o "$payload_dir/$filename"; then
-            fail "Failed to download $filename from branch $branch"
-        fi
-    done
-
-    validate_payload "$payload_dir"
-    INSTALL_SOURCE="unverified branch $branch"
+    download_unverified_payload "$branch" "unverified branch $branch"
 }
 
 resolve_latest_release() {
@@ -466,5 +591,8 @@ echo "Installing fan-control v$RESOLVED_VERSION from $INSTALL_SOURCE"
 install_validated_payload
 
 echo "Installation successful!"
+if ((UNVERIFIED_RELEASE)); then
+    echo "WARNING: Installed v$RESOLVED_VERSION without SHA256 verification"
+fi
 echo "Configuration: nano $INSTALL_DIR/config"
 echo "Status check: journalctl -u fan-control.service -f"

--- a/install.sh
+++ b/install.sh
@@ -149,6 +149,13 @@ validate_archive_header_types() {
     while ((block * 512 < raw_size)); do
         dd if="$raw_archive" of="$header" bs=512 skip="$block" count=1 status=none
         if cmp -s "$header" "$zero_block"; then
+            if (((block + 1) * 512 >= raw_size)); then
+                fail "Release archive has a malformed end marker"
+            fi
+            dd if="$raw_archive" of="$header" bs=512 skip="$((block + 1))" count=1 status=none
+            if ! cmp -s "$header" "$zero_block"; then
+                fail "Release archive has a malformed end marker"
+            fi
             found_end=1
             break
         fi
@@ -165,7 +172,7 @@ validate_archive_header_types() {
 
         size_field=$(dd if="$header" bs=1 skip=124 count=12 status=none | tr -d '\000 ')
         if [[ -z "$size_field" ]]; then
-            size=0
+            fail "Release archive has an invalid entry size"
         elif [[ "$size_field" =~ ^[0-7]+$ ]]; then
             size=$(octal_to_decimal "$size_field")
         else
@@ -370,7 +377,9 @@ download_verified_release() {
         fail "Checksum mismatch for $archive_name"
     fi
 
-    # BusyBox strips leading / and ../ here, so raw-header validation remains required.
+    # GNU tar 1.34 on device preserves traversal paths and flags hardlinks; BusyBox
+    # tar in CI strips paths and misreports hardlinks. Raw-header validation keeps
+    # these checks independent of which tar is present.
     if ! tar -tzf "$archive" >"$WORK_DIR/archive-files"; then
         fail "Release archive could not be listed"
     fi

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -175,7 +175,8 @@ append_tar_entry() {
     local name="$2"
     local type="$3"
     local header="$archive.header"
-    local body="${4:-payload}"
+    local body="${4-payload}"
+    local size_mode="${5:-normal}"
     local checksum
     local padding
 
@@ -187,7 +188,11 @@ append_tar_entry() {
     printf '0000644\0' | dd of="$header" bs=1 seek=100 conv=notrunc status=none
     printf '0000000\0' | dd of="$header" bs=1 seek=108 conv=notrunc status=none
     printf '0000000\0' | dd of="$header" bs=1 seek=116 conv=notrunc status=none
-    printf '%011o\0' "${#body}" | dd of="$header" bs=1 seek=124 conv=notrunc status=none
+    if [[ "$size_mode" == empty ]]; then
+        dd if=/dev/zero of="$header" bs=1 seek=124 count=12 conv=notrunc status=none
+    else
+        printf '%011o\0' "${#body}" | dd of="$header" bs=1 seek=124 conv=notrunc status=none
+    fi
     printf '%011o\0' 0 | dd of="$header" bs=1 seek=136 conv=notrunc status=none
     printf '        ' | dd of="$header" bs=1 seek=148 conv=notrunc status=none
     printf '%s' "$type" | dd of="$header" bs=1 seek=156 conv=notrunc status=none
@@ -209,6 +214,98 @@ append_tar_entry() {
         dd if=/dev/zero bs=1 count="$padding" status=none
     } >>"$archive"
     rm -f "$header"
+}
+
+write_archive_checksum() {
+    local archive="$1"
+    local checksum
+
+    checksum=$(sha256sum "$archive" | awk '{print $1}')
+    printf '%s  unifi-fan-control-v%s.tar.gz\n' "$checksum" "$MOCK_VERSION" >"$CASE_DIR/SHA256SUMS"
+}
+
+compress_raw_archive() {
+    local raw_archive="$1"
+    local archive="$2"
+
+    gzip -c "$raw_archive" >"$archive"
+    rm -f "$raw_archive"
+    write_archive_checksum "$archive"
+}
+
+make_handbuilt_release_archive() {
+    local archive="$1"
+    local raw_archive="$archive.raw"
+
+    : >"$raw_archive"
+    append_tar_entry "$raw_archive" fan-control.sh 0 $'#!/bin/bash\n'
+    append_tar_entry "$raw_archive" uninstall.sh 0 $'#!/bin/bash\n'
+    append_tar_entry "$raw_archive" fan-control.service 0 $'[Unit]\n'
+    append_tar_entry "$raw_archive" VERSION 0 "$MOCK_VERSION"
+    dd if=/dev/zero bs=512 count=2 status=none >>"$raw_archive"
+    compress_raw_archive "$raw_archive" "$archive"
+}
+
+make_lone_zero_block_archive() {
+    local archive="$1"
+    local raw_archive="$archive.raw"
+
+    : >"$raw_archive"
+    append_tar_entry "$raw_archive" uninstall.sh 0 $'#!/bin/bash\n'
+    dd if=/dev/zero bs=512 count=1 status=none >>"$raw_archive"
+    append_tar_entry "$raw_archive" fan-control.sh 2
+    append_tar_entry "$raw_archive" fan-control.service 0 $'[Unit]\n'
+    append_tar_entry "$raw_archive" VERSION 0 "$MOCK_VERSION"
+    dd if=/dev/zero bs=512 count=2 status=none >>"$raw_archive"
+    compress_raw_archive "$raw_archive" "$archive"
+}
+
+make_empty_size_archive() {
+    local archive="$1"
+    local raw_archive="$archive.raw"
+
+    : >"$raw_archive"
+    append_tar_entry "$raw_archive" fan-control.sh 0 "" empty
+    append_tar_entry "$raw_archive" ignored 0 ""
+    append_tar_entry "$raw_archive" uninstall.sh 0 $'#!/bin/bash\n'
+    append_tar_entry "$raw_archive" fan-control.service 0 $'[Unit]\n'
+    append_tar_entry "$raw_archive" VERSION 0 "$MOCK_VERSION"
+    dd if=/dev/zero bs=512 count=2 status=none >>"$raw_archive"
+    compress_raw_archive "$raw_archive" "$archive"
+}
+
+stub_tar_for_header_walk() {
+    local real_tar
+
+    real_tar=$(command -v tar)
+    cat >"$SANDBOX/bin/tar" <<STUB
+#!/usr/bin/env bash
+if [[ "\$1" == "-tzf" ]]; then
+    printf '%s\n' fan-control.sh uninstall.sh fan-control.service VERSION
+    exit 0
+fi
+if [[ "\$1" == "-xzf" ]]; then
+    while (( \$# > 0 )); do
+        case "\$1" in
+            -C)
+                payload_dir="\$2"
+                shift 2
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+    mkdir -p "\$payload_dir"
+    printf '#!/bin/bash\n' >"\$payload_dir/fan-control.sh"
+    printf '#!/bin/bash\n' >"\$payload_dir/uninstall.sh"
+    printf '[Unit]\n' >"\$payload_dir/fan-control.service"
+    printf '%s\n' "$MOCK_VERSION" >"\$payload_dir/VERSION"
+    exit 0
+fi
+exec "$real_tar" "\$@"
+STUB
+    chmod +x "$SANDBOX/bin/tar"
 }
 
 make_hostile_archive() {
@@ -590,6 +687,45 @@ test_hostile_archives_keep_destination() {
     done
 }
 
+test_lone_zero_block_is_rejected_by_header_walk() {
+    local output
+
+    prepare_case lone-zero-block
+    MOCK_VERSION=1.2.3
+    make_lone_zero_block_archive "$CASE_DIR/unifi-fan-control-v${MOCK_VERSION}.tar.gz"
+    seed_old_install
+
+    stub_tar_for_header_walk
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3)
+    rm -f "$SANDBOX/bin/tar"
+    assert_contains "$output" "Release archive has a malformed end marker" "lone zero block rejection: "
+}
+
+test_empty_size_field_is_rejected_by_header_walk() {
+    local output
+
+    prepare_case empty-size-field
+    MOCK_VERSION=1.2.3
+    make_empty_size_archive "$CASE_DIR/unifi-fan-control-v${MOCK_VERSION}.tar.gz"
+    seed_old_install
+
+    stub_tar_for_header_walk
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3)
+    rm -f "$SANDBOX/bin/tar"
+    assert_contains "$output" "Release archive has an invalid entry size" "empty size field rejection: "
+}
+
+test_handbuilt_well_formed_archive_installs() {
+    prepare_case handbuilt-archive
+    MOCK_VERSION=1.2.3
+    make_handbuilt_release_archive "$CASE_DIR/unifi-fan-control-v${MOCK_VERSION}.tar.gz"
+
+    install_environment FAN_CONTROL_VERSION=1.2.3 >/dev/null
+
+    assert_file_set
+    assert_eq "$(cat "$INSTALL_DIR/VERSION")" "$MOCK_VERSION" "handbuilt archive version: "
+}
+
 test_syntax_failure_keeps_destination() {
     prepare_case syntax-failure
     MOCK_VERSION=1.2.3
@@ -675,6 +811,9 @@ test_unverified_fallback_separates_http_failure_from_reachability
 test_checksum_mismatch_keeps_destination
 test_unrelated_checksum_cannot_pass_vacuously
 test_hostile_archives_keep_destination
+test_lone_zero_block_is_rejected_by_header_walk
+test_empty_size_field_is_rejected_by_header_walk
+test_handbuilt_well_formed_archive_installs
 test_syntax_failure_keeps_destination
 test_oversized_payload_keeps_destination
 test_oversized_expansion_keeps_destination

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -73,9 +73,33 @@ while (($# > 0)); do
     esac
 done
 
-if [[ "${MOCK_CURL_FAIL:-0}" == 1 ]]; then
-    exit 22
-fi
+    case "${MOCK_CURL_FAIL:-}" in
+        1)
+            exit 22
+            ;;
+        asset-dns)
+            if [[ "$url" == *.tar.gz ]]; then
+                echo "curl: (6) Could not resolve host: release-assets.githubusercontent.com" >&2
+                exit 6
+            fi
+            ;;
+        fallback-timeout)
+            if [[ "$url" == *raw.githubusercontent.com/* ]]; then
+                echo "curl: (28) Connection timed out after 10001 milliseconds" >&2
+                exit 28
+            fi
+            if [[ "$url" == *.tar.gz ]]; then
+                echo "curl: (6) Could not resolve host: release-assets.githubusercontent.com" >&2
+                exit 6
+            fi
+            ;;
+        archive-http)
+            if [[ "$url" == *.tar.gz ]]; then
+                echo "curl: (22) The requested URL returned error: 404" >&2
+                exit 22
+            fi
+            ;;
+    esac
 
 if [[ -n "$write_format" ]]; then
     printf '%s' "${MOCK_LATEST_URL:?missing latest redirect URL}"
@@ -296,6 +320,16 @@ assert_failed_install_keeps_destination() {
     assert_old_install
 }
 
+assert_failed_install_output() {
+    local output
+
+    if output=$(install_environment "$@" 2>&1); then
+        fail "installer accepted invalid input"
+    fi
+    assert_old_install
+    printf '%s\n' "$output"
+}
+
 assert_file_set() {
     local file
 
@@ -388,6 +422,105 @@ test_curl_failure_keeps_destination() {
     seed_old_install
 
     assert_failed_install_keeps_destination FAN_CONTROL_VERSION=1.2.3 MOCK_CURL_FAIL=1
+}
+
+test_asset_host_dns_failure_explains_the_redirect() {
+    prepare_case asset-host-dns
+    MOCK_VERSION=1.2.3
+    make_payload_dir "$CASE_DIR/branch" "$MOCK_VERSION"
+    seed_old_install
+
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3 MOCK_CURL_FAIL=asset-dns)
+
+    assert_contains "$output" "DNS lookup failed for release-assets.githubusercontent.com" "DNS host diagnosis: "
+    assert_contains "$output" "GitHub redirects release downloads to release-assets.githubusercontent.com" "redirect diagnosis: "
+    assert_contains "$output" "resolver problem, not a fault in the installer or release" "resolver diagnosis: "
+    assert_contains "$output" "Unverified fallback host raw.githubusercontent.com is reachable for v1.2.3" "fallback reachability: "
+    assert_contains "$output" "curl -fsSL https://raw.githubusercontent.com/iceteaSA/unifi-fan-control/v1.2.3/install.sh | sudo FAN_CONTROL_ALLOW_UNVERIFIED=v1.2.3 bash" "consent command: "
+}
+
+test_http_release_failure_does_not_blame_dns() {
+    prepare_case archive-http
+    MOCK_VERSION=1.2.3
+    make_payload_dir "$CASE_DIR/branch" "$MOCK_VERSION"
+    seed_old_install
+
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3 MOCK_CURL_FAIL=archive-http)
+
+    assert_contains "$output" "HTTP error 404 while downloading release v1.2.3" "HTTP diagnosis: "
+    assert_contains "$output" "This is not a DNS resolution failure" "non-DNS diagnosis: "
+    if [[ "$output" == *"resolver problem"* ]]; then
+        fail "HTTP failure was blamed on the resolver: $output"
+    fi
+}
+
+test_unverified_consent_installs_the_failed_release() {
+    prepare_case unverified-consent
+    MOCK_VERSION=1.2.3
+    make_payload_dir "$CASE_DIR/branch" "$MOCK_VERSION"
+
+    output=$(install_environment FAN_CONTROL_VERSION=1.2.3 FAN_CONTROL_ALLOW_UNVERIFIED=v1.2.3 MOCK_CURL_FAIL=asset-dns 2>&1)
+
+    assert_file_set
+    assert_eq "$(cat "$INSTALL_DIR/VERSION")" "$MOCK_VERSION" "unverified release version: "
+    assert_contains "$output" "WARNING: SHA256 verification will be skipped for release v1.2.3" "pre-install warning: "
+    assert_contains "$output" "WARNING: Installed v1.2.3 without SHA256 verification" "post-install warning: "
+    assert_contains "$(cat "$CURL_LOG")" "raw.githubusercontent.com/iceteaSA/unifi-fan-control/v1.2.3/fan-control.sh" "unverified release URL: "
+}
+
+test_unverified_consent_still_validates_the_payload() {
+    prepare_case unverified-validation
+    MOCK_VERSION=1.2.3
+    make_payload_dir "$CASE_DIR/branch" "$MOCK_VERSION"
+    printf 'if then\n' >"$CASE_DIR/branch/fan-control.sh"
+    seed_old_install
+
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3 FAN_CONTROL_ALLOW_UNVERIFIED=v1.2.3 MOCK_CURL_FAIL=asset-dns)
+
+    assert_contains "$output" "Payload scripts failed syntax validation" "unverified payload validation: "
+}
+
+test_unverified_consent_must_match_the_release_tag() {
+    prepare_case unverified-wrong-tag
+    MOCK_VERSION=1.2.3
+    seed_old_install
+
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3 FAN_CONTROL_ALLOW_UNVERIFIED=v1.2.4)
+
+    assert_contains "$output" "FAN_CONTROL_ALLOW_UNVERIFIED must match requested release tag: v1.2.3" "tag mismatch: "
+    assert_eq "$(cat "$CURL_LOG")" "" "tag mismatch made a network call: "
+}
+
+test_unverified_consent_must_name_a_release_tag() {
+    prepare_case unverified-invalid-tag
+    MOCK_VERSION=1.2.3
+    seed_old_install
+
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3 FAN_CONTROL_ALLOW_UNVERIFIED=1)
+
+    assert_contains "$output" "FAN_CONTROL_ALLOW_UNVERIFIED must name a release tag" "tag format: "
+    assert_eq "$(cat "$CURL_LOG")" "" "invalid tag made a network call: "
+}
+
+test_unverified_fallback_reports_when_the_host_is_unreachable() {
+    prepare_case fallback-timeout
+    MOCK_VERSION=1.2.3
+    make_payload_dir "$CASE_DIR/branch" "$MOCK_VERSION"
+    seed_old_install
+
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3 MOCK_CURL_FAIL=fallback-timeout)
+
+    assert_contains "$output" "Unverified fallback host raw.githubusercontent.com is not reachable for v1.2.3 (curl exit 28)" "fallback timeout: "
+}
+
+test_unverified_fallback_separates_http_failure_from_reachability() {
+    prepare_case fallback-http
+    MOCK_VERSION=1.2.3
+    seed_old_install
+
+    output=$(assert_failed_install_output FAN_CONTROL_VERSION=1.2.3 MOCK_CURL_FAIL=1)
+
+    assert_contains "$output" "Unverified fallback host raw.githubusercontent.com responded, but the VERSION request failed (curl exit 22)" "fallback HTTP response: "
 }
 
 test_checksum_mismatch_keeps_destination() {
@@ -498,7 +631,7 @@ test_verified_release_installs_and_preserves_config() {
     make_release_fixture "$CASE_DIR" "$MOCK_VERSION"
     printf 'MIN_TEMP=48\n' >"$INSTALL_DIR/config"
 
-    install_environment FAN_CONTROL_VERSION=1.2.3
+    output=$(install_environment FAN_CONTROL_VERSION=1.2.3)
 
     assert_file_set
     assert_eq "$(stat -c%a "$INSTALL_DIR")" "700" "install directory mode: "
@@ -506,6 +639,7 @@ test_verified_release_installs_and_preserves_config() {
     assert_eq "$(cat "$INSTALL_DIR/config")" "MIN_TEMP=48" "config preservation: "
     assert_eq "$(stat -c%a "$INSTALL_DIR/config")" "600" "installed config mode: "
     assert_eq "$(cat "$SYSTEMCTL_LOG")" $'is-active --quiet fan-control.service\ndaemon-reload\nenable --now fan-control.service\nis-active --quiet fan-control.service' "systemctl order: "
+    assert_eq "$output" $'Installing fan-control v1.2.3 from verified release v1.2.3\nPerforming fresh installation\nInstallation successful!\nConfiguration: nano '"$INSTALL_DIR"$'/config\nStatus check: journalctl -u fan-control.service -f' "verified release output: "
 }
 
 test_restart_failure_restores_prior_payload() {
@@ -530,6 +664,14 @@ test_latest_resolves_a_concrete_verified_release
 test_branch_install_is_unverified
 test_version_and_branch_fail_before_network
 test_curl_failure_keeps_destination
+test_asset_host_dns_failure_explains_the_redirect
+test_http_release_failure_does_not_blame_dns
+test_unverified_consent_installs_the_failed_release
+test_unverified_consent_still_validates_the_payload
+test_unverified_consent_must_match_the_release_tag
+test_unverified_consent_must_name_a_release_tag
+test_unverified_fallback_reports_when_the_host_is_unreachable
+test_unverified_fallback_separates_http_failure_from_reachability
 test_checksum_mismatch_keeps_destination
 test_unrelated_checksum_cannot_pass_vacuously
 test_hostile_archives_keep_destination


### PR DESCRIPTION
Two unrelated installer problems, both surfaced by real users today.

## 1 · A DNS failure that read like our bug

From #41, a UniFi NVR:

```
curl: (6) Could not resolve host: release-assets.githubusercontent.com
Error: Failed to download release archive: v1.2.0
```

Connectivity was fine. `github.com/OWNER/REPO/releases/download/...` doesn't serve the file — it answers **302** and redirects to `release-assets.githubusercontent.com`, so a release install needs **two** hostnames to resolve. That second one is new enough that filtering resolvers and IDS signature sets don't know it.

Two users hit this class today (the other via Tailscale MagicDNS). Both initially read it as an installer bug, because `Failed to download release archive` says nothing.

Now the failure is diagnosed before it's reported — DNS failures name the host and explain the redirect; 404s, timeouts and TLS errors get their own messages and explicitly do *not* blame DNS.

When the verified path fails, the installer **fails** and prints the exact command to proceed without verification:

```
curl -fsSL .../install.sh | sudo FAN_CONTROL_ALLOW_UNVERIFIED=v1.2.3 bash
```

The env var names a specific tag, so it authorises one install rather than becoming a blanket opt-out; a mismatched tag is refused. The skip is announced before and after. Everything except the checksum still runs — archive validation, syntax checks, atomic install with rollback.

**Not a prompt**, deliberately. `read` under `curl | bash` consumes the next line of the piped script — verified, the following `echo` vanishes entirely — and the `read < /dev/tty` workaround fails on the actual hardware (`/dev/tty: No such device or address` on a UCG-Max with a TTY allocated). An env var is consent that survives automation and lands in shell history.

#41 turned out to be firewall IDS dropping the traffic rather than DNS filtering, which the new message would have pointed at correctly either way.

## 2 · Two desync bugs in the tar header walk

Found by adversarial review. `validate_archive_header_types` walks raw 512-byte headers checking the type byte at offset 156. Reaching entry N+1 requires reading entry N's size and skipping — so anything that corrupts that walk means the next "header" read lands in attacker-controlled file data.

**A lone zero block ended the walk.** POSIX requires two. An archive shaped `[entry][one zero block][symlink][proper terminator]` passed validation completely — the walk stopped at the lone block and never examined the symlink, while GNU tar warns and keeps going. Built that archive and confirmed it.

**An empty size field defaulted to `size=0`**, advancing the walk one block so the next 512 bytes were read as a header — a planted block looking like a benign entry passes.

Both now fail. Verified *not* affected: GNU base-256 sizes (`0x80` survives `tr -d '\000 '` then fails `^[0-7]+$`), truncated walks (full walk, no N limit), and `L`/`K`/`x`/`g` types — the type check is a whitelist, only ASCII `0` passes.

## 3 · A comment that was wrong about which tar runs

`install.sh` said *"BusyBox strips leading / and ../ here"*. Measured on a live UCG-Max: `tar` is **GNU tar 1.34** at `/bin/tar`. A BusyBox v1.30.1 binary exists with a `tar` applet, but it isn't what `tar` resolves to.

| | hardlink in `-tv` | leading `/` and `../` |
|---|---|---|
| GNU tar 1.34 (device, install path) | `hrw-` flagged correctly | **preserved** |
| BusyBox tar (Alpine CI, device applet) | `-rw-` misreported | stripped |

Wrong in both directions for the install path: on-device tar preserves traversal paths rather than sanitising them, and does flag hardlinks. The stripping and misreporting are the CI container's behaviour. Comment corrected to what was measured.

## Verification

Mutation-checked:

| Mutation | Result |
|---|---|
| Remove the consent gate | `FAIL: installer accepted invalid input` |
| Remove the redirect diagnosis | `FAIL: redirect diagnosis` |
| Disable the tag match | `FAIL: tag mismatch` |
| Revert the two-zero-block requirement | `FAIL: installer accepted invalid input` |
| Revert empty-size to `size=0` | `FAIL: installer accepted invalid input` |

The malformed archives are built byte-by-byte in the test — no tar tool produces them — reusing the existing `append_tar_entry` machinery, shell-only so it works in the Alpine containers where python3 is absent.

Regression guard beyond the suite: the **real published v1.2.0 tarball** was run through the stricter walk and still validates, so the tightening doesn't reject honest releases.

`bash -n` clean · shellcheck 0 (v0.11.0) · shfmt clean (v3.13.1) · 15 passed on host and bash 4.4 / 5.1 / 5.2.

## Worth knowing for later

SHA256 is verified **before** any header parsing, so this validator only ever runs on an archive that already matched a published checksum. The threat it defends requires an attacker who controls the repo *and* `SHA256SUMS` — who would instead edit `install.sh`, which is fetched unverified by `curl | sudo bash`.

That's an argument for replacing the tarball with per-file checksums entirely and deleting ~100 lines of hand-rolled binary parsing. Not doing it here; the bugs above are real either way and worth fixing regardless of what happens to the archive.