### PR TITLE
fix: stop losing fans that were stopped at startup, and stop out-logging the rate cap

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -247,6 +247,10 @@ ubnt-systool cputemp
 journalctl -u fan-control.service -n 20 | grep "TEMP:"
 ```
 
+`TEMP:` is logged when the raw or smoothed value changes. A quiet `TEMP:`
+stream is normal at a stable temperature; `STATUS:` remains the heartbeat and
+is written every 10 control cycles.
+
 **Common causes**:
 
 1. **Smoothing effect**: System uses exponential smoothing
@@ -539,6 +543,9 @@ journalctl -u fan-control.service | grep "STATUS:"
 ```bash
 # Temperature trends (last hour)
 journalctl -u fan-control.service --since "1 hour ago" | grep "TEMP:"
+
+# Daemon heartbeat and current temperature
+journalctl -u fan-control.service --since "1 hour ago" | grep "STATUS:"
 
 # PWM adjustments (last hour)
 journalctl -u fan-control.service --since "1 hour ago" | grep "SET:"

--- a/fan-control.sh
+++ b/fan-control.sh
@@ -566,9 +566,12 @@ DRIVE_LAST_FLOOR_TEMP=0
 DRIVE_LAST_FLOOR_PWM=0
 DRIVE_LAST_CHECK=0
 DRIVE_ALL_READ_FAILURE_LOGGED=false
-LAST_TEMP_LOG=""
-LAST_CALC_LOG=""
-LAST_DEADBAND_LOG=""
+LOG_TEMP_CHANGE_THRESHOLD=2
+LAST_LOGGED_RAW_TEMP=""
+LAST_LOGGED_SMOOTHED_TEMP=""
+LAST_LOGGED_RAW_SMOOTH_DELTA=""
+LAST_LOGGED_CALC_TEMP=""
+LAST_LOGGED_DEADBAND_TEMP=""
 
 # Function to safely write to a file using atomic operations
 atomic_write_file() {
@@ -619,6 +622,25 @@ else
 fi
 
 # MUST be called directly, never via $(...) — state must persist in the parent shell.
+has_meaningful_temp_change() {
+    local current_temp=$1
+    local last_logged_temp=$2
+
+    if [[ -z "$last_logged_temp" ]]; then
+        return 0
+    fi
+
+    local temp_delta=$((current_temp - last_logged_temp))
+    if ((temp_delta < 0)); then
+        temp_delta=$((-temp_delta))
+    fi
+
+    if ((temp_delta >= LOG_TEMP_CHANGE_THRESHOLD)); then
+        return 0
+    fi
+    return 1
+}
+
 get_smoothed_temp() {
     local raw_temp_output
     raw_temp_output=$(ubnt-systool cputemp 2>/dev/null)
@@ -658,10 +680,27 @@ get_smoothed_temp() {
         atomic_write_file "$TEMP_STATE_FILE" "$SMOOTHED_TEMP"
     fi
 
+    local raw_smooth_delta=$((raw_temp - SMOOTHED_TEMP))
+    if ((raw_smooth_delta < 0)); then
+        raw_smooth_delta=$((-raw_smooth_delta))
+    fi
+
+    local smoothing_progress=false
+    # A large raw jump can settle by one final degree; keep that convergence
+    # visible without treating a one-degree raw flutter as new information.
+    if [[ "$raw_temp" == "$LAST_LOGGED_RAW_TEMP" && -n "$LAST_LOGGED_RAW_SMOOTH_DELTA" ]] &&
+        ((raw_smooth_delta < LAST_LOGGED_RAW_SMOOTH_DELTA)); then
+        smoothing_progress=true
+    fi
+
     local temp_log="TEMP:  RAW=${raw_temp}°C | SMOOTH=${SMOOTHED_TEMP}°C | DELTA=$((raw_temp - SMOOTHED_TEMP))°C"
-    if [[ "$temp_log" != "$LAST_TEMP_LOG" ]]; then
+    if has_meaningful_temp_change "$raw_temp" "$LAST_LOGGED_RAW_TEMP" ||
+        has_meaningful_temp_change "$SMOOTHED_TEMP" "$LAST_LOGGED_SMOOTHED_TEMP" ||
+        [[ "$smoothing_progress" == true ]]; then
         logger -t fan-control "$temp_log"
-        LAST_TEMP_LOG=$temp_log
+        LAST_LOGGED_RAW_TEMP=$raw_temp
+        LAST_LOGGED_SMOOTHED_TEMP=$SMOOTHED_TEMP
+        LAST_LOGGED_RAW_SMOOTH_DELTA=$raw_smooth_delta
     fi
 }
 
@@ -706,9 +745,9 @@ log_calculation() {
     fi
 
     local calc_log="CALC: temp_diff=${temp_diff}°C | range=${temp_range}°C | speed=${speed}pwm"
-    if [[ "$calc_log" != "$LAST_CALC_LOG" ]]; then
+    if has_meaningful_temp_change "$avg_temp" "$LAST_LOGGED_CALC_TEMP"; then
         logger -t fan-control "$calc_log"
-        LAST_CALC_LOG=$calc_log
+        LAST_LOGGED_CALC_TEMP=$avg_temp
     fi
 }
 
@@ -1158,9 +1197,9 @@ update_fan_state() {
                             set_fan_speed "$target_speed"
                         else
                             local deadband_log="DEADBAND:  No change | DELTA=${temp_delta}°C"
-                            if [[ "$deadband_log" != "$LAST_DEADBAND_LOG" ]]; then
+                            if has_meaningful_temp_change "$avg_temp" "$LAST_LOGGED_DEADBAND_TEMP"; then
                                 logger -t fan-control "$deadband_log"
-                                LAST_DEADBAND_LOG=$deadband_log
+                                LAST_LOGGED_DEADBAND_TEMP=$avg_temp
                             fi
                         fi
                     fi

--- a/fan-control.sh
+++ b/fan-control.sh
@@ -316,12 +316,23 @@ if ! command -v ubnt-systool >/dev/null 2>&1; then
 fi
 
 ###[ PWM DEVICE DETECTION ]####################################################
-# Detect all active fan PWM channels
-# Populates the FAN_PWM_DEVICES array with writable PWM paths that have spinning fans
+# Detect writable fan PWM channels and retain their availability state.
+# A zero-RPM reading is not proof that a channel has no fan: shutdown leaves
+# channels at zero, and excluding one can leave a fan permanently uncontrolled.
 detect_pwm_devices() {
     local candidates=()
-    local detected=()
     local writable=()
+    local previous_devices=("${FAN_PWM_DEVICES[@]}")
+    local pwm_file
+    local known_pwm
+    local candidate_known
+    local candidate_present
+    local is_initial_detection=false
+    local devices_changed=false
+
+    if [[ "$PWM_DETECTION_INITIALIZED" == false ]]; then
+        is_initial_detection=true
+    fi
 
     # Strategy 1: look for pwm files directly in hwmon class directories
     # Works on: UCG-Max (lm63 driver), UNVR (adt7475, kernel exposes class symlinks)
@@ -342,13 +353,82 @@ detect_pwm_devices() {
         done
     fi
 
-    if [[ ${#candidates[@]} -eq 0 ]]; then
+    if [[ ${#candidates[@]} -eq 0 && "$is_initial_detection" == true ]]; then
         logger -t fan-control "FATAL: No PWM devices found in /sys"
         exit 1
     fi
 
-    # Filter candidates to channels that are writable and have a spinning fan
+    # Keep checking paths seen before: an absent PWM file must be reported as an
+    # exclusion instead of silently disappearing from the controlled set.
+    for known_pwm in "${KNOWN_PWM_DEVICES[@]}"; do
+        candidate_present=false
+        for pwm_file in "${candidates[@]}"; do
+            if [[ "$known_pwm" == "$pwm_file" ]]; then
+                candidate_present=true
+                break
+            fi
+        done
+        if [[ "$candidate_present" == false ]]; then
+            candidates+=("$known_pwm")
+        fi
+    done
+
+    # Filter candidates to channels whose writable state can be proven.
     for pwm_file in "${candidates[@]}"; do
+        # Test actual writability by writing the current value back
+        # (sysfs file permissions are unreliable — a file may show 644 but still be writable by root)
+        local current_val
+        if ! current_val=$(cat "$pwm_file" 2>/dev/null); then
+            if [[ "${PWM_DEVICE_STATUS[$pwm_file]:-}" != "excluded" ]]; then
+                logger -t fan-control "DETECT: ${pwm_file} unavailable, excluding"
+                devices_changed=true
+            fi
+            PWM_DEVICE_STATUS["$pwm_file"]="excluded"
+            continue
+        fi
+        if ! echo "$current_val" >"$pwm_file" 2>/dev/null; then
+            if [[ "${PWM_DEVICE_STATUS[$pwm_file]:-}" != "excluded" ]]; then
+                logger -t fan-control "DETECT: ${pwm_file} unavailable, excluding"
+                devices_changed=true
+            fi
+            PWM_DEVICE_STATUS["$pwm_file"]="excluded"
+            continue
+        fi
+        writable+=("$pwm_file")
+
+        candidate_known=false
+        for known_pwm in "${KNOWN_PWM_DEVICES[@]}"; do
+            if [[ "$known_pwm" == "$pwm_file" ]]; then
+                candidate_known=true
+                break
+            fi
+        done
+        if [[ "$candidate_known" == false ]]; then
+            KNOWN_PWM_DEVICES+=("$pwm_file")
+        fi
+    done
+
+    if [[ "$is_initial_detection" == true ]]; then
+        if [[ ${#writable[@]} -eq 0 ]]; then
+            logger -t fan-control "FATAL: No writable PWM devices found"
+            exit 1
+        fi
+
+        # MAX_PWM never slows a fan that was already cooling a hot device. Two
+        # seconds clears the measured one-second RPM registration point without
+        # waiting for the six-second settling time.
+        for pwm_file in "${writable[@]}"; do
+            if ! echo "$MAX_PWM" >"$pwm_file" 2>/dev/null; then
+                logger -t fan-control "DETECT: ${pwm_file} unavailable, excluding"
+                PWM_DEVICE_STATUS["$pwm_file"]="excluded"
+            fi
+        done
+        logger -t fan-control "DETECT: Probing writable PWM channels at ${MAX_PWM}pwm for 2s"
+        sleep 2
+    fi
+
+    FAN_PWM_DEVICES=()
+    for pwm_file in "${writable[@]}"; do
         local pwm_dir
         pwm_dir=$(dirname "$pwm_file")
         local pwm_name
@@ -359,64 +439,60 @@ detect_pwm_devices() {
 
         [[ -f "$fan_input" ]] && rpm=$(cat "$fan_input" 2>/dev/null || echo 0)
 
-        # Test actual writability by writing the current value back
-        # (sysfs file permissions are unreliable — a file may show 644 but still be writable by root)
-        local current_val
-        current_val=$(cat "$pwm_file" 2>/dev/null) || continue
-        if ! echo "$current_val" >"$pwm_file" 2>/dev/null; then
-            logger -t fan-control "DETECT: ${pwm_file} not writable, skipping"
-            continue
+        if [[ "${PWM_DEVICE_STATUS[$pwm_file]:-}" == "excluded" ]]; then
+            logger -t fan-control "DETECT: ${pwm_file} writable again, including"
+            devices_changed=true
+            if ((LAST_PWM >= 0)); then
+                if ! echo "$LAST_PWM" >"$pwm_file" 2>/dev/null; then
+                    logger -t fan-control "ERROR: Failed to restore PWM device $pwm_file after detection"
+                    PWM_DEVICE_STATUS["$pwm_file"]="excluded"
+                    continue
+                fi
+            fi
         fi
-        writable+=("$pwm_file")
+        PWM_DEVICE_STATUS["$pwm_file"]="controlled"
+        FAN_PWM_DEVICES+=("$pwm_file")
 
-        if ((rpm > 0)); then
-            detected+=("$pwm_file")
-            logger -t fan-control "DETECT: ${pwm_file} -> fan${fan_num} = ${rpm} RPM (active)"
-        else
-            logger -t fan-control "DETECT: ${pwm_file} -> fan${fan_num} = 0 RPM (skipped)"
+        if [[ "$is_initial_detection" == true ]]; then
+            if ((rpm > 0)); then
+                logger -t fan-control "DETECT: ${pwm_file} -> fan${fan_num} = ${rpm} RPM (active)"
+            else
+                logger -t fan-control "DETECT: ${pwm_file} -> fan${fan_num} = 0 RPM (unknown, controlled)"
+            fi
         fi
     done
 
-    # If no fans were spinning, fall back to all writable PWM channels
-    # (handles cold boot or devices where fans only spin when PWM > 0)
-    if [[ ${#detected[@]} -eq 0 ]]; then
-        logger -t fan-control "DETECT: No spinning fans found, using all writable PWM channels"
-        for pwm_file in "${writable[@]}"; do
-            detected+=("$pwm_file")
-        done
+    if [[ ${#FAN_PWM_DEVICES[@]} -eq 0 ]]; then
+        if [[ "$is_initial_detection" == true ]]; then
+            logger -t fan-control "FATAL: No writable PWM devices found"
+            exit 1
+        fi
+        logger -t fan-control "ERROR: No writable PWM devices found during periodic detection"
     fi
 
-    if [[ ${#detected[@]} -eq 0 ]]; then
-        logger -t fan-control "FATAL: No writable PWM devices found"
-        exit 1
-    fi
-
-    FAN_PWM_DEVICES=("${detected[@]}")
-    logger -t fan-control "DETECT: Controlling ${#FAN_PWM_DEVICES[@]} fan(s): ${FAN_PWM_DEVICES[*]}"
-
-    for pwm_file in "${writable[@]}"; do
-        local controlled=false
-        local controlled_pwm
-        local current_val
-
-        for controlled_pwm in "${FAN_PWM_DEVICES[@]}"; do
-            if [[ "$pwm_file" == "$controlled_pwm" ]]; then
-                controlled=true
+    if [[ ${#previous_devices[@]} -ne ${#FAN_PWM_DEVICES[@]} ]]; then
+        devices_changed=true
+    else
+        for pwm_file in "${!FAN_PWM_DEVICES[@]}"; do
+            if [[ "${FAN_PWM_DEVICES[$pwm_file]}" != "${previous_devices[$pwm_file]}" ]]; then
+                devices_changed=true
                 break
             fi
         done
+    fi
 
-        if [[ "$controlled" == false ]]; then
-            current_val=$(cat "$pwm_file" 2>/dev/null) || continue
-            if [[ "$current_val" != 0 ]]; then
-                logger -t fan-control "DETECT: ${pwm_file} = ${current_val} (not controlled)"
-            fi
-        fi
-    done
+    if [[ "$is_initial_detection" == true || "$devices_changed" == true ]]; then
+        logger -t fan-control "DETECT: Controlling ${#FAN_PWM_DEVICES[@]} fan(s): ${FAN_PWM_DEVICES[*]}"
+    fi
+    PWM_DETECTION_INITIALIZED=true
 }
 
 # Determine PWM devices to control
 FAN_PWM_DEVICES=()
+KNOWN_PWM_DEVICES=()
+declare -A PWM_DEVICE_STATUS=()
+PWM_DETECTION_INITIALIZED=false
+PWM_RECHECK_LOOPS=10
 if [[ "$FAN_PWM_AUTODETECT" != "false" ]]; then
     detect_pwm_devices
 else
@@ -1113,8 +1189,17 @@ get_state_name() {
 
 # Main loop
 declare -i loop_counter=0
+declare -i pwm_recheck_counter=0
 while true; do
     update_fan_state
+
+    if [[ "$FAN_PWM_AUTODETECT" != "false" ]]; then
+        pwm_recheck_counter=$((pwm_recheck_counter + 1))
+        if ((pwm_recheck_counter >= PWM_RECHECK_LOOPS)); then
+            detect_pwm_devices
+            pwm_recheck_counter=0
+        fi
+    fi
 
     # Log status every 10 iterations
     ((loop_counter++ % 10 == 0)) && {

--- a/fan-control.sh
+++ b/fan-control.sh
@@ -566,6 +566,9 @@ DRIVE_LAST_FLOOR_TEMP=0
 DRIVE_LAST_FLOOR_PWM=0
 DRIVE_LAST_CHECK=0
 DRIVE_ALL_READ_FAILURE_LOGGED=false
+LAST_TEMP_LOG=""
+LAST_CALC_LOG=""
+LAST_DEADBAND_LOG=""
 
 # Function to safely write to a file using atomic operations
 atomic_write_file() {
@@ -655,7 +658,11 @@ get_smoothed_temp() {
         atomic_write_file "$TEMP_STATE_FILE" "$SMOOTHED_TEMP"
     fi
 
-    logger -t fan-control "TEMP:  RAW=${raw_temp}°C | SMOOTH=${SMOOTHED_TEMP}°C | DELTA=$((raw_temp - SMOOTHED_TEMP))°C"
+    local temp_log="TEMP:  RAW=${raw_temp}°C | SMOOTH=${SMOOTHED_TEMP}°C | DELTA=$((raw_temp - SMOOTHED_TEMP))°C"
+    if [[ "$temp_log" != "$LAST_TEMP_LOG" ]]; then
+        logger -t fan-control "$temp_log"
+        LAST_TEMP_LOG=$temp_log
+    fi
 }
 
 calculate_speed() {
@@ -682,8 +689,27 @@ calculate_speed() {
     # Ensure speed doesn't exceed MAX_PWM
     speed=$((speed > MAX_PWM ? MAX_PWM : speed))
 
-    logger -t fan-control "CALC: temp_diff=${temp_diff}°C | range=${temp_range}°C | speed=${speed}pwm"
-    echo $speed
+    echo "$speed"
+}
+
+log_calculation() {
+    local avg_temp=$1
+    local speed=$2
+    local temp_range=$((MAX_TEMP - FAN_ACTIVATION_TEMP))
+    local temp_diff=$((avg_temp - FAN_ACTIVATION_TEMP))
+
+    if ((temp_diff < 0)); then
+        temp_diff=0
+    fi
+    if ((temp_range <= 0)); then
+        temp_range=1
+    fi
+
+    local calc_log="CALC: temp_diff=${temp_diff}°C | range=${temp_range}°C | speed=${speed}pwm"
+    if [[ "$calc_log" != "$LAST_CALC_LOG" ]]; then
+        logger -t fan-control "$calc_log"
+        LAST_CALC_LOG=$calc_log
+    fi
 }
 
 json_number() {
@@ -1074,6 +1100,7 @@ update_fan_state() {
                     CURRENT_STATE=$STATE_ACTIVE
                     local calculated_speed
                     calculated_speed=$(calculate_speed "$avg_temp")
+                    log_calculation "$avg_temp" "$calculated_speed"
                     set_fan_speed "$calculated_speed"
                 else
                     # Stay in emergency mode
@@ -1119,16 +1146,22 @@ update_fan_state() {
                         logger -t fan-control "DEADBAND:  DELTA=${temp_delta}°C | THRESHOLD=${DEADBAND}°C"
                         local speed
                         speed=$(calculate_speed "$avg_temp")
+                        log_calculation "$avg_temp" "$speed"
                         set_fan_speed "$speed"
                     else
                         # Force adjustment if we're below target PWM
                         local target_speed
                         target_speed=$(calculate_speed "$avg_temp")
+                        log_calculation "$avg_temp" "$target_speed"
                         if ((LAST_PWM < target_speed)); then
                             logger -t fan-control "DEADBAND:  Forcing adjustment (current ${LAST_PWM}pwm < target ${target_speed}pwm)"
                             set_fan_speed "$target_speed"
                         else
-                            logger -t fan-control "DEADBAND:  No change | DELTA=${temp_delta}°C"
+                            local deadband_log="DEADBAND:  No change | DELTA=${temp_delta}°C"
+                            if [[ "$deadband_log" != "$LAST_DEADBAND_LOG" ]]; then
+                                logger -t fan-control "$deadband_log"
+                                LAST_DEADBAND_LOG=$deadband_log
+                            fi
                         fi
                     fi
                 fi

--- a/tests/test_drive_reporting_and_orphan_pwm.sh
+++ b/tests/test_drive_reporting_and_orphan_pwm.sh
@@ -60,25 +60,24 @@ echo "  ✓ Scenario ${scenario}: absent smartctl threshold is reported honestly
 stop_daemon
 cleanup_sandbox
 
-# ── Scenario 3: non-zero writable uncontrolled PWM is warned once ──────────
+# ── Scenario 3: stopped writable PWM is controlled ──────────────────────────
 scenario=$((scenario + 1))
 setup_sandbox
-echo "45" >"$SANDBOX/cputemp"
+echo "70" >"$SANDBOX/cputemp"
 echo 25 >"$SANDBOX/hwmon/hwmon0/pwm2"
 echo 0 >"$SANDBOX/hwmon/hwmon0/fan2_input"
 
 start_daemon
-wait_for_log 'DETECT:.*pwm2.*25.*not controlled' 10 || fail "non-zero uncontrolled PWM was not warned"
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm2" 0
 logs=$(cat "$SANDBOX/syslog")
-assert_eq "$(grep -c 'DETECT:.*pwm2.*25.*not controlled' <<<"$logs" || true)" "1" "uncontrolled PWM warning count: "
-assert_eq "$(cat "$SANDBOX/hwmon/hwmon0/pwm2")" "25" "uncontrolled PWM must not be reset: "
+assert_contains "$logs" 'pwm2.*0 RPM (unknown, controlled)' "stopped writable PWM should remain controlled: "
 
-echo "  ✓ Scenario ${scenario}: non-zero uncontrolled PWM is warned once"
+echo "  ✓ Scenario ${scenario}: stopped writable PWM is controlled"
 
 stop_daemon
 cleanup_sandbox
 
-# ── Scenario 4: zero uncontrolled and controlled PWM channels stay silent ───
+# ── Scenario 4: controlled PWM channels stay silent ─────────────────────────
 scenario=$((scenario + 1))
 setup_sandbox
 echo "45" >"$SANDBOX/cputemp"
@@ -90,10 +89,10 @@ start_daemon
 /bin/sleep 1
 logs=$(cat "$SANDBOX/syslog")
 if grep -q 'DETECT:.*not controlled' <<<"$logs"; then
-    fail "zero uncontrolled or controlled PWM channel emitted a warning"
+    fail "controlled PWM channel emitted an uncontrolled warning"
 fi
 
-echo "  ✓ Scenario ${scenario}: zero uncontrolled and controlled PWM stay silent"
+echo "  ✓ Scenario ${scenario}: controlled PWM channels stay silent"
 
 stop_daemon
 cleanup_sandbox

--- a/tests/test_pwm_detection.sh
+++ b/tests/test_pwm_detection.sh
@@ -11,40 +11,88 @@ trap teardown_sandbox EXIT
 
 declare -i scenario=0
 
-# ── Scenario 1: class-dir strategy finds fan with RPM > 0 ────────────────────
+# ── Scenario 1: single spinning fan remains controlled ───────────────────────
 scenario=$((scenario + 1))
 setup_sandbox
 
-echo "50" >"$SANDBOX/cputemp"
+echo "70" >"$SANDBOX/cputemp"
 
 start_daemon
 assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive"
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0
 
 assert_contains "$(cat "$SANDBOX/syslog")" "fan1" "should detect fan by name"
 
-echo "  ✓ Scenario ${scenario}: Class-dir detection: fan found"
+echo "  ✓ Scenario ${scenario}: Single spinning fan remains controlled"
 
 stop_daemon
 cleanup_sandbox
 
-# ── Scenario 2: fallback to all-writable when no fan is spinning ─────────────
+# ── Scenario 2: all stopped fans remain controlled ───────────────────────────
 scenario=$((scenario + 1))
 setup_sandbox
 
+echo 0 >"$SANDBOX/hwmon/hwmon0/pwm2"
 echo 0 >"$SANDBOX/hwmon/hwmon0/fan1_input"
-echo "50" >"$SANDBOX/cputemp"
+echo 0 >"$SANDBOX/hwmon/hwmon0/fan2_input"
+echo "70" >"$SANDBOX/cputemp"
 
 start_daemon
 assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive"
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm2" 0
 
-assert_contains "$(cat "$SANDBOX/syslog")" "using all writable" "should fall back to all writable"
+assert_contains "$(cat "$SANDBOX/syslog")" "fan1 = 0 RPM" "should report stopped fan as unknown"
 
-echo "  ✓ Scenario ${scenario}: Fallback: all-writable used when no fan spinning"
+echo "  ✓ Scenario ${scenario}: All stopped fans remain controlled"
 
 stop_daemon
 cleanup_sandbox
 
-# ── Scenario 3: non-writable PWM → daemon exits with FATAL ───────────────────
+# ── Scenario 3: partial detection controls a stopped channel ─────────────────
+scenario=$((scenario + 1))
+setup_sandbox
+
+echo 0 >"$SANDBOX/hwmon/hwmon0/pwm2"
+echo 0 >"$SANDBOX/hwmon/hwmon0/fan2_input"
+echo "70" >"$SANDBOX/cputemp"
+
+start_daemon
+assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive"
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm2" 0
+
+echo "  ✓ Scenario ${scenario}: Partial detection controls stopped channel"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 4: excluded channel recovers without restart ────────────────────
+scenario=$((scenario + 1))
+setup_sandbox
+
+mkdir "$SANDBOX/hwmon/hwmon0/pwm2"
+echo 3000 >"$SANDBOX/hwmon/hwmon0/fan2_input"
+echo "70" >"$SANDBOX/cputemp"
+
+start_daemon
+assert_eq "$(daemon_alive && echo "alive" || echo "dead")" "alive"
+wait_for_log "pwm2.*unavailable, excluding"
+
+rm -rf "$SANDBOX/hwmon/hwmon0/pwm2"
+echo 0 >"$SANDBOX/hwmon/hwmon0/pwm2"
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm2" 0 2
+wait_for_log "pwm2.*writable again, including" 2
+
+exclusion_count=$(grep -c "pwm2.*unavailable, excluding" "$SANDBOX/syslog" || true)
+assert_eq "$exclusion_count" "1" "should log the unchanged exclusion once"
+
+echo "  ✓ Scenario ${scenario}: Excluded channel recovers without restart"
+
+stop_daemon
+cleanup_sandbox
+
+# ── Scenario 5: non-writable PWM → daemon exits with FATAL ───────────────────
 scenario=$((scenario + 1))
 setup_sandbox
 

--- a/tests/test_steady_state_log_volume.sh
+++ b/tests/test_steady_state_log_volume.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+###############################################################################
+# Steady-state logging tests
+###############################################################################
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tests/lib/harness.sh
+source "$SCRIPT_DIR/lib/harness.sh"
+trap teardown_sandbox EXIT
+
+setup_sandbox
+
+echo "70" >"$SANDBOX/cputemp"
+start_daemon
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0
+
+# The daemon has reached its stable active state before this sampling window.
+/bin/sleep 1
+before_lines=$(wc -l <"$SANDBOX/syslog")
+/bin/sleep 1
+after_lines=$(wc -l <"$SANDBOX/syslog")
+steady_lines=$((after_lines - before_lines))
+
+if ((steady_lines > 4)); then
+    fail "stable temperature emitted ${steady_lines} lines in 20 cycles; expected at most 4"
+fi
+
+assert_contains "$(cat "$SANDBOX/syslog")" "CONFIG: fan-control" "should retain startup diagnostics"
+assert_contains "$(cat "$SANDBOX/syslog")" "SET:" "should retain PWM changes"
+assert_contains "$(cat "$SANDBOX/syslog")" "STATUS:" "should retain heartbeat"
+
+echo "  ✓ Stable temperature emitted ${steady_lines} lines in 20 cycles"

--- a/tests/test_steady_state_log_volume.sh
+++ b/tests/test_steady_state_log_volume.sh
@@ -31,3 +31,38 @@ assert_contains "$(cat "$SANDBOX/syslog")" "SET:" "should retain PWM changes"
 assert_contains "$(cat "$SANDBOX/syslog")" "STATUS:" "should retain heartbeat"
 
 echo "  ✓ Stable temperature emitted ${steady_lines} lines in 20 cycles"
+
+cleanup_sandbox
+setup_sandbox
+
+echo "66" >"$SANDBOX/cputemp"
+start_daemon
+wait_for_file_gt "$SANDBOX/hwmon/hwmon0/pwm1" 0
+
+# A 1°C flutter is routine hardware noise; a sustained 2°C step is not.
+/bin/sleep 1
+before_tag_lines=$(grep -E -c ' (TEMP|CALC|DEADBAND):' "$SANDBOX/syslog" || true)
+
+for ((iteration = 0; iteration < 30; iteration++)); do
+    if ((iteration % 2 == 0)); then
+        echo "67" >"$SANDBOX/cputemp"
+    else
+        echo "66" >"$SANDBOX/cputemp"
+    fi
+    /bin/sleep 0.08
+done
+
+after_tag_lines=$(grep -E -c ' (TEMP|CALC|DEADBAND):' "$SANDBOX/syslog" || true)
+flutter_lines=$((after_tag_lines - before_tag_lines))
+
+if ((flutter_lines > 6)); then
+    fail "1°C flutter emitted ${flutter_lines} TEMP/CALC/DEADBAND lines in 30 cycles; expected at most 6"
+fi
+
+for temp in 68 70 72; do
+    echo "$temp" >"$SANDBOX/cputemp"
+    /bin/sleep 0.1
+    wait_for_log "TEMP:  RAW=${temp}°C" 2
+done
+
+echo "  ✓ 1°C flutter emitted ${flutter_lines} tagged lines; 66→72 trend remained visible"


### PR DESCRIPTION
Fixes #42 and #46. Both were found while verifying the v1.2.1 install on a UCG-Max — neither was introduced by it.

## #42 — a fan stopped at startup could be lost for the daemon's lifetime

`detect_pwm_devices` read each channel's RPM once and kept only channels reporting > 0. The all-stopped case fell back to every writable channel, but the **partial** case did not: one fan still coasting and another already stopped meant the stopped channel was skipped, the fallback never fired, and that channel went uncontrolled until the next restart.

The EXIT trap sets PWM to 0 on shutdown, so every restart begins with fans stopped. Detection read RPM *before* writing anything, so it was sampling what the previous instance left behind. Measured on a UCG-Max:

```
pwm=0,   +6s:  rpm=0        (fully stopped)
pwm=128, +1s:  rpm=2705
         +2s:  rpm=3609
         +6s:  rpm=4128     (settled)
```

Which channel got skipped depended on which fan happened to still be coasting during that read — non-deterministic and silent. Two restarts on the same box could control different channel sets, with nothing in the log to say so.

Now:
- writable channels are commanded to `MAX_PWM` for 2s before RPM is read, so the reading reflects the fan rather than the previous instance
- a writable channel reading 0 RPM is treated as **unknown, and controlled** — a channel with no fan costs a wasted PWM write; a channel wrongly excluded costs cooling
- channels are re-checked every 10 loops, so a channel that becomes writable later is picked up without a restart
- exclusion and recovery are logged on the transition

`MAX_PWM` for the probe is deliberate: it can never slow a fan that is already cooling a hot device. The probe runs only at initial detection, not on the periodic recheck.

Since every writable channel is now controlled, the "uncontrolled channel holding a non-zero value" warning added in v1.2.1 no longer has a reachable case and is removed.

## #46 — the daemon out-logged its own rate cap

`fan-control.service` allows 10,000 lines/day. Measured on an idle UCG-Max at the default `CHECK_INTERVAL=15`:

```
03:00 -> 779 lines    (270 TEMP, 239 DEADBAND, 239 CALC, 24 STATUS, 6 SET)
09:00 -> 776
12:00 -> 848
14:00 ->  55   <- cap reached, suppressed
16:00 ->  65
```

~19,200/day against a 10,000/day cap, so the budget was gone by midday. Everything diagnostic — `CONFIG:`, `DETECT:`, `DRIVE:` — happens at startup, so a restart in the suppressed half of the day recorded nothing. The v1.2.1 install on my own device lost its entire startup sequence, which is how this was found.

`TEMP:`, `CALC:` and `DEADBAND:` now log on a meaningful change against the last *logged* value rather than every cycle. Comparing against the previous value is not enough: the device oscillates between 66 °C and 67 °C, so 45% of readings differ from their predecessor and half the volume survives.

Replaying the real journal through the new logic:

```
quiet hour:  270 readings -> 8 TEMP lines
busy hour:   243 readings -> 14 TEMP lines
```

At `CHECK_INTERVAL=5` (3x the cycles), the worst observed hour projects to ~4,750 lines/day against the 10,000 cap. The cap is unchanged; it now has real headroom at the lowest supported interval rather than being exceeded at the default one.

A rising temperature still logs promptly — verified against a 66→80 ramp, where only a single +1 °C step is suppressed. `SET:`, state transitions, `STATUS:` (every 10 cycles), and all startup/`ERROR`/`FATAL`/`ALERT` lines are untouched.

## Verification

19 tests pass on host and on bash 4.4, 5.1 and 5.2 under mawk. ShellCheck and shfmt clean.

New coverage: partial detection with one fan stopped, a channel recovering without a restart, exclusion logged on transition rather than every cycle, steady-state volume, and an oscillating-temperature test.

The oscillation test exists because the first attempt at #46 was measured against a fixture holding a constant temperature — where dedup collapses to nothing and the defect cannot appear. It reported 2 lines per 20 cycles and computed 1,728/day; replaying real device data gave 25,056/day at `CHECK_INTERVAL=5`, still 2.5x over the cap. The threshold logic and the oscillation test both came out of that.

Mutations confirmed each assertion fails when its protection is removed: reverting probe-before-read fails partial detection, threshold=1 emits 89 lines per 30 cycles, threshold=7 loses trend visibility, and removing the transition log fails the recovery test.

## Not covered

The probe changes no behaviour beyond the `active` vs `unknown` wording in the startup log, since every writable channel is controlled either way. It costs 2 seconds of startup and briefly spins fans up. It stays for now because knowing a fan is physically present is diagnostically useful, but it is worth revisiting — the alternative is to log `unknown` initially and let the periodic recheck reclassify.